### PR TITLE
Update spells-idrotf.xml to fix parse error

### DIFF
--- a/Sources/WizardsOfTheCoast/Icewind_Dale_Rime_of_the_Frostmaiden/spells-idrotf.xml
+++ b/Sources/WizardsOfTheCoast/Icewind_Dale_Rime_of_the_Frostmaiden/spells-idrotf.xml
@@ -16,11 +16,11 @@ As a bonus action on your turn, you can move the blade up to 30 feet to an unocc
 
 The blade can harmlessly pass through any barrier, including a wall of force.
 
-Source:	Icewind Dale: Rime of the Frostmaiden p. 318</text-->
+Source:	Icewind Dale: Rime of the Frostmaiden p. 318</text>
     <roll>4d12</roll>
     <roll>8d12</roll>
     <roll>12d12</roll>
-  </spell>
+  </spell-->
   <spell>
     <name>Create Magen</name>
     <classes>School: Transformation, Wizard</classes>


### PR DESCRIPTION
Previous commit introduced a parse error due to comment block ending too soon, which left the </spell> tag hanging.