### PR TITLE
Update Swift trait for the Swift Strig

### DIFF
--- a/Sources/WizardsOfTheCoast/Humblewood_Campaign_Setting/races-hcs.xml
+++ b/Sources/WizardsOfTheCoast/Humblewood_Campaign_Setting/races-hcs.xml
@@ -851,7 +851,7 @@ Weight in pounds = 80 + (1d6 × your size modifier)</text>
     </trait>
     <trait>
       <name>Swift</name>
-      <text>Your base walking speed increases to 25 feet.</text>
+      <text>Your base walking speed increases to 35 feet.</text>
     </trait>
     <trait>
       <name>Survivors</name>


### PR DESCRIPTION
Fix Typo.
(Page 21 in the Humblewood campaign book)
<img width="137" alt="image" src="https://github.com/user-attachments/assets/b9ff0502-0f90-4d5a-9f20-e12f50a13b45">
