### PR TITLE
Minor typo fixes

### DIFF
--- a/Sources/Homebrew/Crown_of_the_Oathbreaker/bestiary-coto.xml
+++ b/Sources/Homebrew/Crown_of_the_Oathbreaker/bestiary-coto.xml
@@ -2146,7 +2146,7 @@ Source:	Crown of the Oathbreaker p. 770 (Homebrew)</description>
   </monster>
   <monster>
     <name>Dryad Witch</name>
-    <ancenstry>Dryad</ancenstry>
+    <ancestry>Dryad</ancestry>
     <size>M</size>
     <type>fey</type>
     <alignment>Neutral Evil</alignment>
@@ -2614,7 +2614,7 @@ Source:	Crown of the Oathbreaker p. 776 (Homebrew)</description>
   </monster>
   <monster>
     <name>Frumby Goldtooth</name>
-    <ancenstry>vampire spawn</ancenstry>
+    <ancestry>vampire spawn</ancestry>
     <npc>YES</npc>
     <size>S</size>
     <type>humanoid (goblin)</type>

--- a/Sources/Homebrew/_Cawood_Publishing/Monsters_of_Feyland_1/bestiary-mof.xml
+++ b/Sources/Homebrew/_Cawood_Publishing/Monsters_of_Feyland_1/bestiary-mof.xml
@@ -345,7 +345,7 @@ Summer Court. Centaur mages belong to the Summer Court, a division of the Seelie
 Arcane Focus. The centaur mage's staff is their arcane focus. If it is destroyed or taken away, they lose any ability to cast spells.
 
 Source:	Monsters of Feyland p. 13 (Homebrew)</description>
-    <environemnt>Any</environemnt>
+    <environment>Any</environment>
   </monster>  <!-- Centaur, Mage -->
   <monster>
     <name>Changeling</name>

--- a/Sources/Homebrew/_Cawood_Publishing/Monsters_of_the_Underworld/bestiary-motu.xml
+++ b/Sources/Homebrew/_Cawood_Publishing/Monsters_of_the_Underworld/bestiary-motu.xml
@@ -5041,7 +5041,7 @@ Source:	Monsters of the Underworld p. 73 (Homebrew)</description>
     <wis>3</wis>
     <cha>1</cha>
     <skill>Perception +2</skill>
-    <imune>poison</imune>
+    <immune>poison</immune>
     <conditionImmune>poisoned</conditionImmune>
     <senses>darkvision 60 ft.</senses>
     <passive>12</passive>
@@ -5371,7 +5371,7 @@ Source:	Monsters of the Underworld p. 105 (Homebrew)</description>
     <wis>18</wis>
     <cha>14</cha>
     <save>Con +10, Wis +9</save>
-    <skills>Insight +9, Perception +9</skills>
+    <skill>Insight +9, Perception +9</skill>
     <immune>poison</immune>
     <conditionImmune>charmed, paralyzed, poisoned</conditionImmune>
     <senses>darkvision 60 ft.</senses>

--- a/Sources/Homebrew/_Cawood_Publishing/Monsters_of_the_Wilderness/bestiary-motw.xml
+++ b/Sources/Homebrew/_Cawood_Publishing/Monsters_of_the_Wilderness/bestiary-motw.xml
@@ -15,7 +15,7 @@
     <wis>16</wis>
     <cha>3</cha>
     <skill>Perception +6</skill>
-    <resistance>poison, psychic; bludgeoning, piercing, and slashing from nonmagical attacks</resistance>
+    <resist>poison, psychic; bludgeoning, piercing, and slashing from nonmagical attacks</resist>
     <conditionImmune>prone</conditionImmune>
     <senses>blindsight 60 ft.</senses>
     <passive>16</passive>
@@ -75,7 +75,7 @@ Source:	Monsters of the Wilderness p. 7 (Homebrew)</description>
     <save>Con +9, Wis +5, Int +15</save>
     <skill>Arcana +15, History +15, Investigation +15, Perception +5</skill>
     <vulnerable/>
-    <resistance/>
+    <resist/>
     <immune/>
     <conditionImmune/>
     <senses/>
@@ -146,7 +146,7 @@ Source:	Monsters of the Wilderness p. 147 (Homebrew)</description>
     <save/>
     <skill>Deception +8, Insight +7, Perception +7, Stealth +6</skill>
     <vulnerable/>
-    <resistance>cold, fire; bludgeoning, piercing, and slashing from nonmagical attacks not made with silvered weapons</resistance>
+    <resist>cold, fire; bludgeoning, piercing, and slashing from nonmagical attacks not made with silvered weapons</resist>
     <immune/>
     <conditionImmune>charmed</conditionImmune>
     <senses>darkvision 120 ft.</senses>
@@ -212,7 +212,7 @@ Source:	Monsters of the Wilderness p. 148 (Homebrew)</description>
     <save>Con +12, Int +15, Wis +11</save>
     <skill>Arcana +15, History +15, Insight +11, Perception +11</skill>
     <vulnerable/>
-    <resistance>cold, lightning, necrotic</resistance>
+    <resist>cold, lightning, necrotic</resist>
     <immune>poison; bludgeoning, piercing, and slashing from nonmagical attacks</immune>
     <conditionImmune>charmed, exhaustion, frightened, paralyzed, poisoned</conditionImmune>
     <senses>truesight 120 ft.</senses>
@@ -4016,7 +4016,7 @@ Source:	Monsters of the Wilderness p. 78 (Homebrew)</description>
     <wis>20</wis>
     <cha>19</cha>
     <skill>Insight +8, Perception +8, Survival +8</skill>
-    <sense>darkvision 60 ft.</sense>
+    <senses>darkvision 60 ft.</senses>
     <passive>18</passive>
     <languages>Common, Druidic, Sylvan, Draconic</languages>
     <cr>7</cr>
@@ -4425,7 +4425,7 @@ Source:	Monsters of the Wilderness p. 85 (Homebrew)</description>
     <cha>10</cha>
     <skill>Perception +3, Stealth +5</skill>
     <resist>poison</resist>
-    <sense>darkvision 60 ft.</sense>
+    <senses>darkvision 60 ft.</senses>
     <passive>13</passive>
     <languages>Salaman</languages>
     <cr>1</cr>
@@ -4481,7 +4481,7 @@ Source:	Monsters of the Wilderness p. 86 (Homebrew)</description>
     <skill>Insight +4, Perception +4 Stealth +5</skill>
     <resist>poison</resist>
     <conditionImmune>prone</conditionImmune>
-    <sense>darkvision 60 ft.</sense>
+    <senses>darkvision 60 ft.</senses>
     <passive>14</passive>
     <languages>Salaman</languages>
     <cr>4</cr>
@@ -4538,7 +4538,7 @@ Source:	Monsters of the Wilderness p. 87 (Homebrew)</description>
     <cha>13</cha>
     <skill>Insight +5, Nature +3, Medicine +5, Perception +5</skill>
     <resist>poison</resist>
-    <sense>darkvision 60 ft.</sense>
+    <senses>darkvision 60 ft.</senses>
     <passive>15</passive>
     <languages>Salaman</languages>
     <cr>2</cr>

--- a/Sources/WizardsOfTheCoast/Fizbans_Treasury_of_Dragons/bestiary-ftod.xml
+++ b/Sources/WizardsOfTheCoast/Fizbans_Treasury_of_Dragons/bestiary-ftod.xml
@@ -4331,7 +4331,7 @@ Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 10 (2d6 + 3) slash
     <vulnerable/>
     <immune>determined by the drake's Draconic Essence trait</immune>
     <conditionImmune/>
-    <sense>darkvision 60 ft.</sense>
+    <senses>darkvision 60 ft.</senses>
     <passive>12</passive>
     <languages>draconic</languages>
     <cr>2</cr>

--- a/Sources_2024/Homebrew/WotC_2014_legacy/WizardsOfTheCoast_homebrew_2014_legacy/Fizbans_Treasury_of_Dragons/bestiary-ftod.xml
+++ b/Sources_2024/Homebrew/WotC_2014_legacy/WizardsOfTheCoast_homebrew_2014_legacy/Fizbans_Treasury_of_Dragons/bestiary-ftod.xml
@@ -4331,7 +4331,7 @@ Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 10 (2d6 + 3) slash
     <vulnerable />
     <immune>determined by the drake's Draconic Essence trait</immune>
     <conditionImmune />
-    <sense>darkvision 60 ft.</sense>
+    <senses>darkvision 60 ft.</senses>
     <passive>12</passive>
     <languages>draconic</languages>
     <cr>2</cr>


### PR DESCRIPTION
Hello,
I've found some tags that appear to have a typo (eg. ancenstry → ancestry, environemnt → environment)