### PR TITLE
Fixed school value, EV instead of E for evocation

### DIFF
--- a/Sources/PartneredContent/Humblewood_Campaign_Setting/spells-hcs.xml
+++ b/Sources/PartneredContent/Humblewood_Campaign_Setting/spells-hcs.xml
@@ -97,7 +97,7 @@ Source:	Humblewood Campaign Setting p. 50</text>
     <name>Gust Barrier</name>
     <classes>School: Evocation, Bard, Druid, Sorcerer, Wizard</classes>
     <level>0</level>
-    <school>E</school>
+    <school>EV</school>
     <ritual>NO</ritual>
     <time>1 action</time>
     <range>Self</range>


### PR DESCRIPTION
Found another small typo, school is supposed to be "EV" for evocation and "EN" for enchantment, in this instance it was "E" 