### PR TITLE
T stands for Transmutation - and other fixes

### DIFF
--- a/Sources/Adventures/Icewind_Dale_Rime_of_the_Frostmaiden/spells-idrotf.xml
+++ b/Sources/Adventures/Icewind_Dale_Rime_of_the_Frostmaiden/spells-idrotf.xml
@@ -15,7 +15,7 @@ Source:	Icewind Dale: Rime of the Frostmaiden p. 318</text><roll>4d12</roll><rol
     <range>Touch</range>
     <components>V, S, M (a vial of quicksilver worth 500 gp and a life-sized human doll, both of which the spell consumes, and an intricate crystal rod worth at least 1,500 gp that is not consumed)</components>
     <duration>Instantaneous</duration>
-    <classes>School: Transformation, Wizard</classes>
+    <classes>School: Transmutation, Wizard</classes>
     <text>While casting the spell, you place a vial of quicksilver in the chest of a life-sized human doll stuffed with ash or dust. You then stitch up the doll and drip your blood on it. At the end of the casting, you tap the doll with a crystal rod, transforming it into a magen clothed in whatever the doll was wearing. The type of magen is chosen by you during the casting of the spell. See appendix C for different kinds of magen and their statistics.
 	When the magen appears, your hit point maximum decreases by an amount equal to the magen's challenge rating (minimum reduction of 1). Only a wish spell can undo this reduction to your hit point maximum.
 	Any magen you create with this spell obeys your commands without question.

--- a/Sources/Homebrew/_ElderBrain/Crown_of_the_Oathbreaker/spells-coto.xml
+++ b/Sources/Homebrew/_ElderBrain/Crown_of_the_Oathbreaker/spells-coto.xml
@@ -8,7 +8,7 @@
     <range>60 feet</range>
     <components>V, S, M (a gear made of metal)</components>
     <duration>Concentration, up to 1 minute</duration>
-    <classes>School: Transformation, Bard, Sorcerer, Wizard</classes>
+    <classes>School: Transmutation, Bard, Sorcerer, Wizard</classes>
     <text>Choose a construct that you can see within range. The target must succeed on a Wisdom saving throw or be paralyzed for the duration even if the target is immune to being paralyzed. At the end of each of its turns, the target can make another Wisdom saving throw. On a success, the spell ends on the target.
 
 At Higher Levels: When you cast this spell using a spell slot of 5th level or higher, you can target an additional construct for each slot level above 4th. The constructs must be within 30 feet of each other when you target them.
@@ -36,7 +36,7 @@ Source:	Crown of the Oathbreaker p. 908 (Homebrew)</text>
     <range>60 feet</range>
     <components>V, S, M (tendrils from the roots of an oak)</components>
     <duration>Concentration, up to 1 minute</duration>
-    <classes>School: Transformation, Bard, Sorcerer, Warlock, Wizard</classes>
+    <classes>School: Transmutation, Bard, Sorcerer, Warlock, Wizard</classes>
     <text>Even if this defies gravity, a creature or unattended item you touch becomes magically fixed in place. A creature must succeed on a Strength saving throw or become restrained for the duration. At the end of each of its turns, the target can make another Strength saving throw. On a success, the spell ends on the target. An item immobilized by the spell can hold up to 8,000 pounds of weight. More weight causes the item to fall. A creature can use an action to make a DC 30 Strength check, moving the fixed item up to 10 feet on a success.
 
 At Higher Levels: When you cast this spell on an item using a spell slot of 6th level or higher, the spell lasts until dispelled, without requiring your concentration.
@@ -51,7 +51,7 @@ Source:	Crown of the Oathbreaker p. 909 (Homebrew)</text>
     <range>120 feet</range>
     <components>V, S, M (a pinch of ash)</components>
     <duration>Concentration, up to 1 minute</duration>
-    <classes>School: Transformation, Bard, Sorcerer, Warlock, Wizard</classes>
+    <classes>School: Transmutation, Bard, Sorcerer, Warlock, Wizard</classes>
     <text>You alter the structure of an object or the body of a creature, which starts to lose its structural integrity or decompose.
 	Choose a creature that you can see within range. The target creature must make a Constitution saving throw. On a failed save, it takes 11 (2d10) force damage at the start of its turn and has disadvantage on ability checks and saving throws for the duration. At the end of each of its turns, the target can make another Constitution saving throw. On a success, the spell ends on the target.
 	Choose an object that you can see within range. This spell destroys a large or smaller nonmagical object in three rounds. If the target is a huge object, this spell causes it to become damaged, or renders it useless if it has a complex mechanism or moving parts. A magic item is unaffected by this spell.
@@ -144,7 +144,7 @@ Source:	Crown of the Oathbreaker p. 911 (Homebrew)</text>
     <range>Self</range>
     <components>V, S, M (a page of sheet music)</components>
     <duration>Instantaneous</duration>
-    <classes>School: Transformation, Wizard</classes>
+    <classes>School: Transmutation, Wizard</classes>
     <text>You can cast this spell during an uninterrupted short rest while studying your spellbook. Your mind is transported to the outer reaches of the cosmos, and you hear the music of the spheres, composed of melodies by pure magical energies. During the short rest, you can recover a combined level of spell slots equal to your wizard level when using your arcane recovery class ability.
 
 Source:	Crown of the Oathbreaker p. 911 (Homebrew)</text>

--- a/Sources/PartneredContent/Explorers_Guide_to_Wildemount/spells-egw.xml
+++ b/Sources/PartneredContent/Explorers_Guide_to_Wildemount/spells-egw.xml
@@ -96,7 +96,7 @@ Source:	Explorer's Guide to Wildemount p. 187</text>
     <range>Touch</range>
     <components>V, S, M (gold dust worth at least 25 gp, which the spell consumes)</components>
     <duration>1 hour</duration>
-    <classes>School: Transformation, Wizard (Graviturgy)</classes>
+    <classes>School: Transmutation, Wizard (Graviturgy)</classes>
     <text>You touch an object that weighs no more than 10 pounds and cause it to become magically fixed in place. You and the creatures you designate when you cast this spell can move the object normally. You can also set a password that, when spoken within 5 feet of the object, suppresses this spell for 1 minute.
 	If the object is fixed in the air, it can hold up to 4,000 pounds of weight. More weight causes the object to fall. Otherwise, a creature can use an action to make a Strength check against your spell save DC. On a success, the creature can move the object up to 10 feet.
 
@@ -112,7 +112,7 @@ Source:	Explorer's Guide to Wildemount p. 187</text>
     <range>60 feet</range>
     <components>V, S</components>
     <duration>1 round</duration>
-    <classes>School: Transformation, Wizard (Graviturgy)</classes>
+    <classes>School: Transmutation, Wizard (Graviturgy)</classes>
     <text>The gravity in a 10-foot-radius sphere centered on a point you can see within range increases for a moment. Each creature in the sphere on the turn when you cast the spell must make a Constitution saving throw. On a failed save, a creature takes 2d8 force damage, and its speed is halved until the end of its next turn. On a successful save, a creature takes half as much damage and suffers no reduction to its speed.
 	Until the start of your next turn, any object that isn't being worn or carried in the sphere requires a successful Strength check against your spell save DC to pick up or move.
 
@@ -240,7 +240,7 @@ Source:	Explorer's Guide to Wildemount p. 189</text>
     <range>120 feet</range>
     <components>V, S</components>
     <duration>1 round</duration>
-    <classes>School: Transformation, Wizard (Chronurgy)</classes>
+    <classes>School: Transmutation, Wizard (Chronurgy)</classes>
     <text>You target the triggering creature, which must succeed on a Wisdom saving throw or vanish, being thrown to another point in time and causing the attack to miss or the spell to be wasted. At the start of its next turn, the target reappears where it was or in the closest unoccupied space. The target doesn't remember you casting the spell or being affected by it.
 
 At Higher Levels: When you cast this spell using a spell slot of 6th level or higher, you can target one additional creature for each slot level above 5th. All targets must be within 30 feet of each other.

--- a/Sources/UnearthedArcana/2015/2015-08-03_Modern_Magic/spells-ua-mm.xml
+++ b/Sources/UnearthedArcana/2015/2015-08-03_Modern_Magic/spells-ua-mm.xml
@@ -8,7 +8,7 @@
     <range>Self</range>
     <components>V, S, M (hacking tools)</components>
     <duration>Concentration, up to 1 hour</duration>
-    <classes>School: Transformation, Warlock, Sorcerer, Wizard, Warlock (Ghost in the Machine (UA))</classes>
+    <classes>School: Transmutation, Warlock, Sorcerer, Wizard, Warlock (Ghost in the Machine (UA))</classes>
     <text>You gain advantage on all Intelligence checks using hacking tools to break software encryption or online security when using a foreign system. This spell also allows you to break 2nd-level and lower protective spells such as arcane lock or glyph of warding by making an Intelligence check using hacking tools against the spell save DC of the spell's caster.
 
 At Higher Levels: When you cast this spell using a spell slot of 3rd level or higher, you can attempt to counteract a spell set to secure the foreign system if the spell's level is equal to or less than the level of the spell slot you used.
@@ -146,7 +146,7 @@ Source:	Unearthed Arcana: Modern Magic p. 7</text>
     <range>60 feet</range>
     <components>V, S</components>
     <duration>Instantaneous</duration>
-    <classes>School: Transformation, Warlock, Sorcerer, Wizard</classes>
+    <classes>School: Transmutation, Warlock, Sorcerer, Wizard</classes>
     <text>This cantrip allows you to activate or deactivate any electronic device within range, as long as the device has a clearly defined on or off function that can be easily accessed from the outside of the device. Any device that requires a software-based shutdown sequence to activate or deactivate cannot be affected by on/off.
 
 Source:	Unearthed Arcana: Modern Magic p. 7</text>
@@ -172,7 +172,7 @@ Source:	Unearthed Arcana: Modern Magic p. 8</text>
     <range>120 feet</range>
     <components>V, S</components>
     <duration>10 minutes</duration>
-    <classes>School: Transformation, Warlock, Sorcerer, Wizard, Cleric (City (UA)), Warlock (Ghost in the Machine (UA))</classes>
+    <classes>School: Transmutation, Warlock, Sorcerer, Wizard, Cleric (City (UA)), Warlock (Ghost in the Machine (UA))</classes>
     <text>You can use any electronic device within range as if it were in your hands. This is not a telekinesis effect. Rather, this spell allows you to simulate a device's mechanical functions electronically. You are able to access only functions that a person using the device manually would be able to access. You can use remote access with only one device at a time.
 
 Source:	Unearthed Arcana: Modern Magic p. 8</text>
@@ -185,7 +185,7 @@ Source:	Unearthed Arcana: Modern Magic p. 8</text>
     <range>120 feet</range>
     <components>V, S</components>
     <duration>Concentration, up to 1 minute</duration>
-    <classes>School: Transformation, Warlock, Sorcerer, Wizard, Cleric (City (UA)), Warlock (Ghost in the Machine (UA))</classes>
+    <classes>School: Transmutation, Warlock, Sorcerer, Wizard, Cleric (City (UA)), Warlock (Ghost in the Machine (UA))</classes>
     <text>This spell shuts down all electronic devices within range that are not wielded by or under the direct control of a creature. If an electronic device within range is used by a creature, that creature must succeed on a Constitution saving throw to prevent the device from being shut down. While the spell remains active, no electronic device within range can be started or restarted.
 
 Source:	Unearthed Arcana: Modern Magic p. 8</text>
@@ -213,7 +213,7 @@ Source:	Unearthed Arcana: Modern Magic p. 8</text>
     <range>Self</range>
     <components>V, S, M (hacking tools)</components>
     <duration>Concentration, up to 1 hour</duration>
-    <classes>School: Transformation, Warlock, Sorcerer, Wizard, Warlock (Ghost in the Machine (UA))</classes>
+    <classes>School: Transmutation, Warlock, Sorcerer, Wizard, Warlock (Ghost in the Machine (UA))</classes>
     <text>This spell allows you to bypass system security in order to create a secure login on a foreign system. The login you create allows you administrator-level privileges in any computer system not enhanced through technomagic. The login defeats any technomagic spells of 3rd level or lower.
 	Once the duration of the spell expires, the login and all privileges are wiped from the system. System logs still show the activity of the user, but the user identification cannot be found or traced.
 

--- a/Sources/UnearthedArcana/2017/2017-04-03_Starter_Spells/spells-ua-ss.xml
+++ b/Sources/UnearthedArcana/2017/2017-04-03_Starter_Spells/spells-ua-ss.xml
@@ -152,7 +152,7 @@ Source:	Unearthed Arcana: Starter Spells p. 3</text>
     <range>Self</range>
     <components>S</components>
     <duration>Instantaneous</duration>
-    <classes>School: Transformation, Druid</classes>
+    <classes>School: Transmutation, Druid</classes>
     <text>Your teeth or fingernails lengthen and sharpen. You choose which. Make a melee spell attack against one creature within 5 feet of you. On a hit, the target takes 1d10 piercing or slashing damage (your choice). After you make the attack, your teeth or fingernails return to normal.
 
 Cantrip Upgrade: The spell's damage increases by 1d10 when you reach 5th level (2d10), 11th level (3d10), and 17th level (4d10).
@@ -283,7 +283,7 @@ Source:	Unearthed Arcana: Starter Spells p. 5</text>
     <range>120 feet</range>
     <components>V, S</components>
     <duration>Instantaneous</duration>
-    <classes>School: Transformation, Druid, Ranger</classes>
+    <classes>School: Transmutation, Druid, Ranger</classes>
     <text>You call out to the spirits of nature to aid you. When you cast this spell, choose one of the following effects:
 
 	• If there are any tracks on the ground within range, you know where they are, and you make Wisdom (Survival) checks to follow these tracks with advantage for 1 hour or until you cast this spell again.
@@ -308,7 +308,7 @@ Source:	Unearthed Arcana: Starter Spells p. 5</text>
     <range>Self</range>
     <components>V</components>
     <duration>Concentration, up to 1 minute</duration>
-    <classes>School: Transformation, Ranger</classes>
+    <classes>School: Transmutation, Ranger</classes>
     <text>You move like the wind. For the duration, your movement doesn't provoke opportunity attacks.
 	In addition, the first time you make a weapon attack on your turn before the spell ends, you make the attack roll with advantage, and your speed increases by 30 feet until the end of that turn.
 

--- a/Sources/UnearthedArcana/2019/2019-02-28_Artificer_Revisited/spells-ua-ar.xml
+++ b/Sources/UnearthedArcana/2019/2019-02-28_Artificer_Revisited/spells-ua-ar.xml
@@ -8,7 +8,7 @@
     <range>Self</range>
     <components>V, S</components>
     <duration>Concentration, up to 1 hour</duration>
-    <classes>School: Transformation, Artificer</classes>
+    <classes>School: Transmutation, Artificer</classes>
     <text>You channel arcane energy into one simple or martial weapon you're holding, and choose one damage type: acid, cold, fire, lightning, poison, or thunder. Until the spell ends, you deal an extra 1d6 damage of the chosen type to any target you hit with the weapon. If the weapon isn't magical, it becomes a magic weapon for the spell's duration.
 	As a bonus action, you can change the damage type, choosing from the options above.
 

--- a/Sources/UnearthedArcana/2020/2020-03-26_Spells_and_Magic_Tattoos/spells-ua-2020spellsandmagictattoos.xml
+++ b/Sources/UnearthedArcana/2020/2020-03-26_Spells_and_Magic_Tattoos/spells-ua-2020spellsandmagictattoos.xml
@@ -32,7 +32,7 @@ Source:	Unearthed Arcana: 2020 Spells And Magic Tattoos p. 2</text>
     <range>Self</range>
     <components>V, S, M (an object engraved with a symbol of the Outer Planes, worth at least 500 gp)</components>
     <duration>Concentration, up to 1 minute</duration>
-    <classes>School: Transformation, Cleric, Sorcerer, Warlock, Wizard</classes>
+    <classes>School: Transmutation, Cleric, Sorcerer, Warlock, Wizard</classes>
     <text>Uttering an incantation, you draw on the magic of the Lower Planes or Upper Planes (your choice) to transform yourself. You gain the following benefits until the spell ends:
 
 	• You are immune to fire and poison damage (Lower Planes) or radiant and necrotic damage (Upper Planes).

--- a/Sources/UnearthedArcana/2023/2023-10-05_Bastions_and_Cantrips/spells-ua-bc.xml
+++ b/Sources/UnearthedArcana/2023/2023-10-05_Bastions_and_Cantrips/spells-ua-bc.xml
@@ -112,7 +112,7 @@ Source:	Unearthed Arcana: Bastions and Cantrips p. 23</text>
     <range>Touch</range>
     <components>V, S, M (mistletoe, a shamrock leaf, and a Club or Quarterstaff)</components>
     <duration>1 minute</duration>
-    <classes>School: Transformation, Touch Spells, Druid, Sorcerer (Giant Soul (UA))</classes>
+    <classes>School: Transmutation, Touch Spells, Druid, Sorcerer (Giant Soul (UA))</classes>
     <text>A Club or Quarterstaff you are holding is imbued with nature's power. For the duration, you can use your spellcasting ability instead of Strength for the attack and damage rolls of melee attacks using that weapon, and the weapon's damage die becomes a d8. If the attack deals damage, it can be Force damage or the weapon's normal damage type (your choice).
 	The spell ends early if you cast it again or if you let go of the weapon.
 

--- a/Sources/WizardsOfTheCoast/01_Players_Handbook/spells-phb.xml
+++ b/Sources/WizardsOfTheCoast/01_Players_Handbook/spells-phb.xml
@@ -58,7 +58,7 @@ Source:	Player's Handbook (2014) p. 211</text>
     <range>Self</range>
     <components>V, S</components>
     <duration>Concentration, up to 1 hour</duration>
-    <classes>School: Transformation, Sorcerer, Wizard, Druid (Moon)</classes>
+    <classes>School: Transmutation, Sorcerer, Wizard, Druid (Moon)</classes>
     <text>You assume a different form. When you cast the spell, choose one of the following options, the effects of which last for the duration of the spell. While the spell lasts, you can end one option as an action to gain the benefits of a different one.
 
 Aquatic Adaptation: You adapt your body to an aquatic environment, sprouting gills and growing webbing between your fingers. You can breathe underwater and gain a swimming speed equal to your walking speed.
@@ -114,7 +114,7 @@ Source:	Player's Handbook (2014) p. 212</text>
     <range>30 feet</range>
     <components>V, S</components>
     <duration>Concentration, up to 24 hours</duration>
-    <classes>School: Transformation, Druid</classes>
+    <classes>School: Transmutation, Druid</classes>
     <text>Your magic turns others into beasts. Choose any number of willing creatures that you can see within range. You transform each target into the form of a Large or smaller beast with a challenge rating of 4 or lower. On subsequent turns, you can use your action to transform affected creatures into new forms.
 	The transformation lasts for the duration for each target, or until the target drops to 0 hit points or dies. You can choose a different form for each target. A target's game statistics are replaced by the statistics of the chosen beast, though the target retains its alignment and Intelligence, Wisdom, and Charisma scores. The target assumes the hit points of its new form, and when it reverts to its normal form, it returns to the number of hit points it had before it transformed. If it reverts as a result of dropping to 0 hit points, any excess damage carries over to its normal form. As long as the excess damage doesn't reduce the creature's normal form to 0 hit points, it isn't knocked unconscious. The creature is limited in the actions it can perform by the nature of its new form, and it can't speak or cast spells.
 	The target's gear melds into the new form. The target can't activate, wield, or otherwise benefit from any of its equipment.
@@ -146,7 +146,7 @@ Source:	Player's Handbook (2014) p. 212</text>
     <range>120 feet</range>
     <components>V, S</components>
     <duration>Concentration, up to 1 minute</duration>
-    <classes>School: Transformation, Bard, Sorcerer, Wizard</classes>
+    <classes>School: Transmutation, Bard, Sorcerer, Wizard</classes>
     <text>Objects come to life at your command. Choose up to ten nonmagical objects within range that are not being worn or carried. Medium targets count as two objects, Large targets count as four objects, Huge targets count as eight objects. You can't animate any object larger than Huge. Each target animates and becomes a creature under your control until the spell ends or until reduced to 0 hit points.
 	As a bonus action, you can mentally command any creature you made with this spell if the creature is within 500 feet of you (if you control multiple creatures, you can command any or all of them at the same time, issuing the same command to each one). You decide what action the creature will take and where it will move during its next turn, or you can issue a general command, such as to guard a particular chamber or corridor. If you issue no commands, the creature only defends itself against hostile creatures. Once given an order, the creature continues to follow it until its task is complete.
 
@@ -406,7 +406,7 @@ Source:	Player's Handbook (2014) p. 216</text>
     <range>Touch</range>
     <components>V, S, M (an agate worth at least 1,000 gp, which the spell consumes)</components>
     <duration>Instantaneous</duration>
-    <classes>School: Transformation, Bard, Druid</classes>
+    <classes>School: Transmutation, Bard, Druid</classes>
     <text>After spending the casting time tracing magical pathways within a precious gemstone, you touch a Huge or smaller beast or plant. The target must have either no Intelligence score or an Intelligence of 3 or less. The target gains an Intelligence of 10. The target also gains the ability to speak one language you know. If the target is a plant, it gains the ability to move its limbs, roots, vines, creepers, and so forth, and it gains senses similar to a human's. Your DM chooses statistics appropriate for the awakened plant, such as the statistics for the awakened shrub or the awakened tree.
 	The awakened beast or plant is charmed by you for 30 days or until you or your companions do anything harmful to it. When the charmed condition ends, the awakened creature chooses whether to remain friendly to you, based on how you treated it while it was charmed.
 
@@ -470,7 +470,7 @@ Source:	Player's Handbook (2014) p. 217</text>
     <range>Touch</range>
     <components>V, S, M (a handful of oak bark)</components>
     <duration>Concentration, up to 1 hour</duration>
-    <classes>School: Transformation, Druid, Ranger, Cleric (Nature), Druid (Forest)</classes>
+    <classes>School: Transmutation, Druid, Ranger, Cleric (Nature), Druid (Forest)</classes>
     <text>You touch a willing creature. Until the spell ends, the target's skin has a rough, bark-like appearance, and the target's AC can't be less than 16, regardless of what kind of armor it is wearing.
 
 Source:	Player's Handbook (2014) p. 217</text>
@@ -682,7 +682,7 @@ Source:	Player's Handbook (2014) p. 219</text>
     <range>Self</range>
     <components>V, S</components>
     <duration>1 minute</duration>
-    <classes>School: Transformation, Sorcerer, Wizard, Cleric (Trickery), Warlock (Archfey)</classes>
+    <classes>School: Transmutation, Sorcerer, Wizard, Cleric (Trickery), Warlock (Archfey)</classes>
     <text>Roll a d20 at the end of each of your turns for the duration of the spell. On a roll of 11 or higher, you vanish from your current plane of existence and appear in the Ethereal Plane (the spell fails and the casting is wasted if you were already on that plane). At the start of your next turn, and when the spell ends if you are on the Ethereal Plane, you return to an unoccupied space of your choice that you can see within 10 feet of the space you vanished from. If no unoccupied space is available within that range, you appear in the nearest unoccupied space (chosen at random if more than one space is equally near). You can dismiss this spell as an action.
 	While on the Ethereal Plane, you can see and hear the plane you originated from, which is cast in shades of gray, and you can't see anything there more than 60 feet away. You can only affect and be affected by other creatures on the Ethereal Plane. Creatures that aren't there can't perceive you or interact with you, unless they have the ability to do so.
 
@@ -1408,7 +1408,7 @@ Source:	Player's Handbook (2014) p. 227</text>
     <range>300 feet</range>
     <components>V, S, M (a drop of water and a pinch of dust)</components>
     <duration>Concentration, up to 10 minutes</duration>
-    <classes>School: Transformation, Cleric, Druid, Wizard, Cleric (Tempest), Druid (Coast)</classes>
+    <classes>School: Transmutation, Cleric, Druid, Wizard, Cleric (Tempest), Druid (Coast)</classes>
     <text>Until the spell ends, you control any freestanding water inside an area you choose that is a cube up to 100 feet on a side. You can choose from any of the following effects when you cast this spell. As an action on your turn, you can repeat the same effect or choose a different one.
 
 Flood: You cause the water level of all standing water in the area to rise by as much as 20 feet. If the area includes a shore, the flooding water spills over onto dry land.
@@ -1434,7 +1434,7 @@ Source:	Player's Handbook (2014) p. 227</text>
     <range>Self (5-mile radius)</range>
     <components>V, S, M (burning incense and bits of earth and wood mixed in water)</components>
     <duration>Concentration, up to 8 hours</duration>
-    <classes>School: Transformation, Cleric, Druid, Wizard</classes>
+    <classes>School: Transmutation, Cleric, Druid, Wizard</classes>
     <text>You take control of the weather within 5 miles of you for the duration. You must be outdoors to cast this spell. Moving to a place where you don't have a clear path to the sky ends the spell early.
 	When you cast the spell, you change the current weather conditions, which are determined by the DM based on the climate and season. You can change precipitation, temperature, and wind. It takes 1d4 × 10 minutes for the new conditions to take effect. Once they do so, you can change the conditions again. When the spell ends, the weather gradually returns to normal.
 	When you change the weather conditions, find a current condition on the following tables and change its stage by one, up or down. When changing the wind, you can change its direction.
@@ -1476,7 +1476,7 @@ Source:	Player's Handbook (2014) p. 228</text>
     <range>5 feet</range>
     <components>V, S, M (four or more arrows or bolts)</components>
     <duration>8 hours</duration>
-    <classes>School: Transformation, Ranger</classes>
+    <classes>School: Transmutation, Ranger</classes>
     <text>You plant four pieces of nonmagical ammunition—arrow or crossbow bolt—in the ground within range and lay magic upon them to protect an area. Until the spell ends, whenever a creature other than you comes within 30 feet of the ammunition for the first time on a turn or ends its turn there, one piece of ammunition flies up to strike it. The creature must succeed on a Dexterity saving throw or take 1d6 piercing damage. The piece of ammunition is then destroyed. The spell ends when no ammunition remains.
 	When you cast this spell, you can designate any creatures you choose, and the spell ignores them.
 
@@ -1521,7 +1521,7 @@ Source:	Player's Handbook (2014) p. 229</text>
     <range>30 feet</range>
     <components>V, S, M (a drop of water if creating water or a few grains of sand if destroying it)</components>
     <duration>Instantaneous</duration>
-    <classes>School: Transformation, Cleric, Druid</classes>
+    <classes>School: Transmutation, Cleric, Druid</classes>
     <text>You either create or destroy water.
 
 Create Water: You create up to 10 gallons of clean water within range in an open container. Alternatively, the water falls as rain in a 30-foot cube within range, extinguishing exposed flames in the area.
@@ -1669,7 +1669,7 @@ Source:	Player's Handbook (2014) p. 230</text>
     <range>Touch</range>
     <components>V, S, M (either a pinch of dried carrot or an agate)</components>
     <duration>8 hours</duration>
-    <classes>School: Transformation, Druid, Ranger, Sorcerer, Wizard</classes>
+    <classes>School: Transmutation, Druid, Ranger, Sorcerer, Wizard</classes>
     <text>You touch a willing creature to grant it the ability to see in the dark. For the duration, that creature has darkvision out to a range of 60 feet.
 
 Source:	Player's Handbook (2014) p. 230</text>
@@ -1860,7 +1860,7 @@ Source:	Player's Handbook (2014) p. 233</text>
     <range>60 feet</range>
     <components>V, S, M (a lodestone and a pinch of dust)</components>
     <duration>Instantaneous</duration>
-    <classes>School: Transformation, Sorcerer, Wizard</classes>
+    <classes>School: Transmutation, Sorcerer, Wizard</classes>
     <text>A thin green ray springs from your pointing finger to a target that you can see within range. The target can be a creature, an object, or a creation of magical force, such as the wall created by wall of force.
 	A creature targeted by this spell must make a Dexterity saving throw. On a failed save, the target takes 10d6 + 40 force damage. The target is disintegrated if this damage leaves it with 0 hit points.
 	A disintegrated creature and everything it is wearing and carrying, except magic items, are reduced to a pile of fine gray dust. The creature can be restored to life only by means of a true resurrection or a wish spell.
@@ -2103,7 +2103,7 @@ Source:	Player's Handbook (2014) p. 236</text>
     <range>30 feet</range>
     <components>V, S</components>
     <duration>Instantaneous</duration>
-    <classes>School: Transformation, Druid</classes>
+    <classes>School: Transmutation, Druid</classes>
     <text>Whispering to the spirits of nature, you create one of the following effects within range:
 
 	• You create a tiny, harmless sensory effect that predicts what the weather will be at your location for the next 24 hours. The effect might manifest as a golden orb for clear skies, a cloud for rain, falling snowflakes for snow, and so on. This effect persists for 1 round.
@@ -2168,7 +2168,7 @@ Source:	Player's Handbook (2014) p. 237</text>
     <range>Touch</range>
     <components>V, S</components>
     <duration>Concentration, up to 1 hour</duration>
-    <classes>School: Transformation, Paladin</classes>
+    <classes>School: Transmutation, Paladin</classes>
     <text>A nonmagical weapon you touch becomes a magic weapon. Choose one of the following damage types: acid, cold, fire, lightning, or thunder. For the duration, the weapon has a +1 bonus to attack rolls and deals an extra 1d4 damage of the chosen type when it hits.
 
 At Higher Levels: When you cast this spell using a spell slot of 5th or 6th level, the bonus to attack rolls increases to +2 and the extra damage increases to 2d4. When you use a spell slot of 7th level or higher, the bonus increases to +3 and the extra damage increases to 3d4.
@@ -2186,7 +2186,7 @@ Source:	Player's Handbook (2014) p. 237</text>
     <range>Touch</range>
     <components>V, S, M (fur or a feather from a beast)</components>
     <duration>Concentration, up to 1 hour</duration>
-    <classes>School: Transformation, Bard, Cleric, Druid, Sorcerer</classes>
+    <classes>School: Transmutation, Bard, Cleric, Druid, Sorcerer</classes>
     <text>You touch a creature and bestow upon it a magical enhancement. Choose one of the following effects; the target gains that effect until the spell ends.
 
 Bear's Endurance: The target has advantage on Constitution checks. It also gains 2d6 temporary hit points, which are lost when the spell ends.
@@ -2214,7 +2214,7 @@ Source:	Player's Handbook (2014) p. 237</text>
     <range>30 feet</range>
     <components>V, S, M (a pinch of powdered iron)</components>
     <duration>Concentration, up to 1 minute</duration>
-    <classes>School: Transformation, Sorcerer, Wizard</classes>
+    <classes>School: Transmutation, Sorcerer, Wizard</classes>
     <text>You cause a creature or an object you can see within range to grow larger or smaller for the duration. Choose either a creature or an object that is neither worn nor carried. If the target is unwilling, it can make a Constitution saving throw. On a success, the spell has no effect.
 	If the target is a creature, everything it is wearing and carrying changes size with it. Any item dropped by an affected creature returns to normal size at once.
 
@@ -2287,7 +2287,7 @@ Source:	Player's Handbook (2014) p. 238</text>
     <range>Self</range>
     <components>V, S</components>
     <duration>8 hours</duration>
-    <classes>School: Transformation, Bard, Cleric, Sorcerer, Warlock, Wizard</classes>
+    <classes>School: Transmutation, Bard, Cleric, Sorcerer, Warlock, Wizard</classes>
     <text>You step into the border regions of the Ethereal Plane, in the area where it overlaps with your current plane. You remain in the Border Ethereal for the duration or until you use your action to dismiss the spell. During this time, you can move in any direction. If you move up or down, every foot of movement costs an extra foot. You can see and hear the plane you originated from, but everything there looks gray, and you can't see anything more than 60 feet away.
 	While on the Ethereal Plane, you can only affect and be affected by other creatures on that plane. Creatures that aren't on the Ethereal Plane can't perceive you and can't interact with you, unless a special ability or magic has given them the ability to do so.
 	You ignore all objects and effects that aren't on the Ethereal Plane, allowing you to move through objects you perceive on the plane you originated from.
@@ -2322,7 +2322,7 @@ Source:	Player's Handbook (2014) p. 238</text>
     <range>Self</range>
     <components>V, S</components>
     <duration>Concentration, up to 10 minutes</duration>
-    <classes>School: Transformation, Sorcerer, Warlock, Wizard</classes>
+    <classes>School: Transmutation, Sorcerer, Warlock, Wizard</classes>
     <text>This spell allows you to move at an incredible pace. When you cast this spell, and then as a bonus action on each of your turns until the spell ends, you can take the Dash action.
 
 Source:	Player's Handbook (2014) p. 238</text>
@@ -2368,7 +2368,7 @@ Source:	Player's Handbook (2014) p. 238</text>
     <range>120 feet</range>
     <components>V, S</components>
     <duration>Instantaneous</duration>
-    <classes>School: Transformation, Fighter (Eldritch Knight), Wizard</classes>
+    <classes>School: Transmutation, Fighter (Eldritch Knight), Wizard</classes>
     <text>You convert raw materials into products of the same material. For example, you can fabricate a wooden bridge from a clump of trees, a rope from a patch of hemp, and clothes from flax or wool.
 	Choose raw materials that you can see within range. You can fabricate a Large or smaller object (contained within a 10-foot cube, or eight connected 5-foot cubes), given a sufficient quantity of raw material. If you are working with metal, stone, or another mineral substance, however, the fabricated object can be no larger than Medium (contained within a single 5-foot cube). The quality of objects made by the spell is commensurate with the quality of the raw materials.
 	Creatures or magic items can't be created or transmuted by this spell. You also can't use it to create items that ordinarily require a high degree of craftsmanship, such as jewelry, weapons, glass, or armor, unless you have proficiency with the type of artisan's tools used to craft such objects.
@@ -2427,7 +2427,7 @@ Source:	Player's Handbook (2014) p. 239</text>
     <range>60 feet</range>
     <components>V, M (a small feather or a piece of down)</components>
     <duration>1 minute</duration>
-    <classes>School: Transformation, Bard, Sorcerer, Wizard</classes>
+    <classes>School: Transmutation, Bard, Sorcerer, Wizard</classes>
     <text>Choose up to five falling creatures within range. A falling creature's rate of descent slows to 60 feet per round until the spell ends. If the creature lands before the spell ends, it takes no falling damage and can land on its feet, and the spell ends for that creature.
 
 Source:	Player's Handbook (2014) p. 239</text>
@@ -2703,7 +2703,7 @@ Source:	Player's Handbook (2014) p. 242</text>
     <range>60 feet</range>
     <components>V, S, M (a pinch of lime, water, and earth)</components>
     <duration>Concentration, up to 1 minute</duration>
-    <classes>School: Transformation, Warlock, Wizard</classes>
+    <classes>School: Transmutation, Warlock, Wizard</classes>
     <text>You attempt to turn one creature that you can see within range into stone. If the target's body is made of flesh, the creature must make a Constitution saving throw. On a failed save, it is restrained as its flesh begins to harden. On a successful save, the creature isn't affected.
 	A creature restrained by this spell must make another Constitution saving throw at the end of each of its turns. If it successfully saves against this spell three times, the spell ends. If it fails its saves three times, it is turned to stone and subjected to the petrified condition for the duration. The successes and failures don't need to be consecutive; keep track of both until the target collects three of a kind.
 	If the creature is physically broken while petrified, it suffers from similar deformities if it reverts to its original state.
@@ -2727,7 +2727,7 @@ Source:	Player's Handbook (2014) p. 243</text>
     <range>Touch</range>
     <components>V, S, M (a wing feather from any bird)</components>
     <duration>Concentration, up to 10 minutes</duration>
-    <classes>School: Transformation, Sorcerer, Warlock, Wizard</classes>
+    <classes>School: Transmutation, Sorcerer, Warlock, Wizard</classes>
     <text>You touch a willing creature. The target gains a flying speed of 60 feet for the duration. When the spell ends, the target falls if it is still aloft, unless it can stop the fall.
 
 At Higher Levels: When you cast this spell using a spell slot of 4th level or higher, you can target one additional creature for each slot level above 3rd.
@@ -2834,7 +2834,7 @@ Source:	Player's Handbook (2014) p. 244</text>
     <range>Touch</range>
     <components>V, S, M (a bit of gauze and a wisp of smoke)</components>
     <duration>Concentration, up to 1 hour</duration>
-    <classes>School: Transformation, Sorcerer, Warlock, Wizard, Druid (Underdark)</classes>
+    <classes>School: Transmutation, Sorcerer, Warlock, Wizard, Druid (Underdark)</classes>
     <text>You transform a willing creature you touch, along with everything it's wearing and carrying, into a misty cloud for the duration. The spell ends if the creature drops to 0 hit points. An incorporeal creature isn't affected.
 	While in this form, the target's only method of movement is a flying speed of 10 feet. The target can enter and occupy the space of another creature. The target has resistance to nonmagical damage, and it has advantage on Strength, Dexterity, and Constitution saving throws. The target can pass through small holes, narrow openings, and even mere cracks, though it treats liquids as though they were solid surfaces. The target can't fall and remains hovering in the air even when stunned or otherwise incapacitated.
 	While in the form of a misty cloud, the target can't talk or manipulate objects, and any objects it was carrying or holding can't be dropped, used, or otherwise interacted with. The target can't attack or cast spells.
@@ -2902,7 +2902,7 @@ Source:	Player's Handbook (2014) p. 245</text>
     <range>30 feet</range>
     <components>V, S</components>
     <duration>Concentration, up to 10 minutes</duration>
-    <classes>School: Transformation, Druid</classes>
+    <classes>School: Transmutation, Druid</classes>
     <text>You transform up to ten centipedes, three spiders, five wasps, or one scorpion within range into giant versions of their natural forms for the duration. A centipede becomes a giant centipede, a spider becomes a giant spider, a wasp becomes a giant wasp, and a scorpion becomes a giant scorpion.
 	Each creature obeys your verbal commands, and in combat, they act on your turn each round. The DM has the statistics for these creatures and resolves their actions and movement.
 	A creature remains in its giant size for the duration, until it drops to 0 hit points, or until you use an action to dismiss the effect on it.
@@ -2918,7 +2918,7 @@ Source:	Player's Handbook (2014) p. 245</text>
     <range>Self</range>
     <components>V</components>
     <duration>1 hour</duration>
-    <classes>School: Transformation, Bard, Warlock</classes>
+    <classes>School: Transmutation, Bard, Warlock</classes>
     <text>Until the spell ends, when you make a Charisma check, you can replace the number you roll with a 15. Additionally, no matter what you say, magic that would determine if you are telling the truth indicates that you are being truthful.
 
 Source:	Player's Handbook (2014) p. 245</text>
@@ -2978,7 +2978,7 @@ Source:	Player's Handbook (2014) p. 245</text>
     <range>Touch</range>
     <components>V, S, M (a sprig of mistletoe)</components>
     <duration>Instantaneous</duration>
-    <classes>School: Transformation, Druid, Ranger</classes>
+    <classes>School: Transmutation, Druid, Ranger</classes>
     <text>Up to ten berries appear in your hand and are infused with magic for the duration. A creature can use its action to eat one berry. Eating a berry restores 1 hit point, and the berry provides enough nourishment to sustain a creature for one day.
 	The berries lose their potency if they have not been consumed within 24 hours of the casting of this spell.
 
@@ -3243,7 +3243,7 @@ Source:	Player's Handbook (2014) p. 249</text>
     <range>30 feet</range>
     <components>V, S, M (a shaving of licorice root)</components>
     <duration>Concentration, up to 1 minute</duration>
-    <classes>School: Transformation, Sorcerer, Wizard, Druid (Grassland), Paladin (Vengeance)</classes>
+    <classes>School: Transmutation, Sorcerer, Wizard, Druid (Grassland), Paladin (Vengeance)</classes>
     <text>Choose a willing creature that you can see within range. Until the spell ends, the target's speed is doubled, it gains a +2 bonus to AC, it has advantage on Dexterity saving throws, and it gains an additional action on each of its turns. That action can be used only to take the Attack (one weapon attack only), Dash, Disengage, Hide, or Use an Object action.
 	When the spell ends, the target can't move or take actions until after its next turn, as a wave of lethargy sweeps over it.
 
@@ -3296,7 +3296,7 @@ Source:	Player's Handbook (2014) p. 250</text>
     <range>60 feet</range>
     <components>V, S, M (a piece of iron and a flame)</components>
     <duration>Concentration, up to 1 minute</duration>
-    <classes>School: Transformation, Bard, Druid</classes>
+    <classes>School: Transmutation, Bard, Druid</classes>
     <text>Choose a manufactured metal object, such as a metal weapon or a suit of heavy or medium metal armor, that you can see within range. You cause the object to glow red-hot. Any creature in physical contact with the object takes 2d8 fire damage when you cast the spell. Until the spell ends, you can use a bonus action on each of your subsequent turns to cause this damage again.
 	If a creature is holding or wearing the object and takes the damage from it, the creature must succeed on a Constitution saving throw or drop the object if it can. If it doesn't drop the object, it has disadvantage on attack rolls and ability checks until the start of your next turn.
 
@@ -3681,7 +3681,7 @@ Source:	Player's Handbook (2014) p. 254</text>
     <range>Touch</range>
     <components>V, S, M (a grasshopper's hind leg)</components>
     <duration>1 minute</duration>
-    <classes>School: Transformation, Druid, Ranger, Sorcerer, Wizard</classes>
+    <classes>School: Transmutation, Druid, Ranger, Sorcerer, Wizard</classes>
     <text>You touch a creature. The creature's jump distance is tripled until the spell ends.
 
 Source:	Player's Handbook (2014) p. 254</text>
@@ -3694,7 +3694,7 @@ Source:	Player's Handbook (2014) p. 254</text>
     <range>60 feet</range>
     <components>V</components>
     <duration>Instantaneous</duration>
-    <classes>School: Transformation, Bard, Sorcerer, Wizard</classes>
+    <classes>School: Transmutation, Bard, Sorcerer, Wizard</classes>
     <text>Choose an object that you can see within range. The object can be a door, a box, a chest, a set of manacles, a padlock, or another object that contains a mundane or magical means that prevents access.
 	A target that is held shut by a mundane lock or that is stuck or barred becomes unlocked, unstuck, or unbarred. If the object has multiple locks, only one of them is unlocked.
 	If you choose a target that is held shut with arcane lock, that spell is suppressed for 10 minutes, during which time the target can be opened and shut normally.
@@ -3768,7 +3768,7 @@ Source:	Player's Handbook (2014) p. 255</text>
     <range>60 feet</range>
     <components>V, S, M (either a small leather loop or a piece of golden wire bent into a cup shape with a long shank on one end)</components>
     <duration>Concentration, up to 10 minutes</duration>
-    <classes>School: Transformation, Sorcerer, Wizard</classes>
+    <classes>School: Transmutation, Sorcerer, Wizard</classes>
     <text>One creature or loose object of your choice that you can see within range rises vertically, up to 20 feet, and remains suspended there for the duration. The spell can levitate a target that weighs up to 500 pounds. An unwilling creature that succeeds on a Constitution saving throw is unaffected.
 	The target can move only by pushing or pulling against a fixed object or surface within reach (such as a wall or a ceiling), which allows it to move as if it were climbing. You can change the target's altitude by up to 20 feet in either direction on your turn. If you are the target, you can move up or down as part of your move. Otherwise, you can use your action to move the target, which must remain within the spell's range.
 	When the spell ends, the target floats gently to the ground if it is still aloft.
@@ -3797,7 +3797,7 @@ Source:	Player's Handbook (2014) p. 255</text>
     <range>Self</range>
     <components>V, S</components>
     <duration>Concentration, up to 1 minute</duration>
-    <classes>School: Transformation, Ranger</classes>
+    <classes>School: Transmutation, Ranger</classes>
     <text>The next time you make a ranged weapon attack during the spell's duration, the weapon's ammunition, or the weapon itself if it's a thrown weapon, transforms into a bolt of lightning. Make the attack roll as normal. The target takes 4d8 lightning damage on a hit, or half as much damage on a miss, instead of the weapon's normal damage.
 	Whether you hit or miss, each creature within 10 feet of the target must make a Dexterity saving throw. Each of these creatures takes 2d8 lightning damage on a failed save, or half as much damage on a successful one.
 	The piece of ammunition or weapon then returns to its normal form.
@@ -3890,7 +3890,7 @@ Source:	Player's Handbook (2014) p. 256</text>
     <range>Touch</range>
     <components>V, S, M (a pinch of dirt)</components>
     <duration>1 hour</duration>
-    <classes>School: Transformation, Bard, Druid, Ranger, Wizard</classes>
+    <classes>School: Transmutation, Bard, Druid, Ranger, Wizard</classes>
     <text>You touch a creature. The target's speed increases by 10 feet until the spell ends.
 
 At Higher Levels: When you cast this spell using a spell slot of 2nd level or higher, you can target one additional creature for each slot level above 1st.
@@ -4008,7 +4008,7 @@ Source:	Player's Handbook (2014) p. 257</text>
     <range>Touch</range>
     <components>V, S</components>
     <duration>Concentration, up to 1 hour</duration>
-    <classes>School: Transformation, Paladin, Wizard, Cleric (War)</classes>
+    <classes>School: Transmutation, Paladin, Wizard, Cleric (War)</classes>
     <text>You touch a nonmagical weapon. Until the spell ends, that weapon becomes a magic weapon with a +1 bonus to attack rolls and damage rolls.
 
 At Higher Levels: When you cast this spell using a spell slot of 4th level or higher, the bonus increases to +2. When you use a spell slot of 6th level or higher, the bonus increases to +3.
@@ -4131,7 +4131,7 @@ Source:	Player's Handbook (2014) p. 258</text>
     <range>Touch</range>
     <components>V, S</components>
     <duration>8 hours</duration>
-    <classes>School: Transformation, Cleric, Druid, Druid (Mountain)</classes>
+    <classes>School: Transmutation, Cleric, Druid, Druid (Mountain)</classes>
     <text>You step into a stone object or surface large enough to fully contain your body, melding yourself and all the equipment you carry with the stone for the duration. Using your movement, you step into the stone at a point you can touch. Nothing of your presence remains visible or otherwise detectable by nonmagical senses.
 	While merged with the stone, you can't see what occurs outside it, and any Wisdom (Perception) checks you make to hear sounds outside it are made with disadvantage. You remain aware of the passage of time and can cast spells on yourself while merged in the stone. You can use your movement to leave the stone where you entered it, which ends the spell. You otherwise can't move.
 	Minor physical damage to the stone doesn't harm you, but its partial destruction or a change in its shape (to the extent that you no longer fit within it) expels you and deals 6d6 bludgeoning damage to you. The stone's complete destruction (or transmutation into a different substance) expels you and deals 50 bludgeoning damage to you. If expelled, you fall prone in an unoccupied space closest to where you first entered.
@@ -4176,7 +4176,7 @@ Source:	Player's Handbook (2014) p. 259</text>
     <range>Touch</range>
     <components>V, S, M (two lodestones)</components>
     <duration>Instantaneous</duration>
-    <classes>School: Transformation, Fighter (Eldritch Knight), Rogue (Arcane Trickster), Bard, Cleric, Druid, Sorcerer, Wizard</classes>
+    <classes>School: Transmutation, Fighter (Eldritch Knight), Rogue (Arcane Trickster), Bard, Cleric, Druid, Sorcerer, Wizard</classes>
     <text>This spell repairs a single break or tear in an object you touch, such as broken chain link, two halves of a broken key, a torn cloak, or a leaking wineskin. As long as the break or tear is no larger than 1 foot in any dimension, you mend it, leaving no trace of the former damage.
 	This spell can physically repair a magic item or construct, but the spell can't restore magic to such an object.
 
@@ -4190,7 +4190,7 @@ Source:	Player's Handbook (2014) p. 259</text>
     <range>120 feet</range>
     <components>V, S, M (a short piece of copper wire)</components>
     <duration>1 round</duration>
-    <classes>School: Transformation, Fighter (Eldritch Knight), Rogue (Arcane Trickster), Bard, Sorcerer, Wizard</classes>
+    <classes>School: Transmutation, Fighter (Eldritch Knight), Rogue (Arcane Trickster), Bard, Sorcerer, Wizard</classes>
     <text>You point your finger toward a creature within range and whisper a message. The target (and only the target) hears the message and can reply in a whisper that only you can hear.
 	You can cast this spell through solid objects if you are familiar with the target and know it is beyond the barrier. Magical silence, 1 foot of stone, 1 inch of common metal, a thin sheet of lead, or 3 feet of wood blocks the spell. The spell doesn't have to follow a straight line and can travel freely around corners or through openings.
 
@@ -4443,7 +4443,7 @@ Source:	Player's Handbook (2014) p. 262</text>
     <range>120 feet</range>
     <components>V, S, M (an iron blade and a small bag containing a mixture of soils—clay, loam, and sand)</components>
     <duration>Concentration, up to 2 hours</duration>
-    <classes>School: Transformation, Druid, Sorcerer, Wizard</classes>
+    <classes>School: Transmutation, Druid, Sorcerer, Wizard</classes>
     <text>Choose an area of terrain no larger than 40 feet on a side within range. You can reshape dirt, sand, or clay in the area in any manner you choose for the duration. You can raise or lower the area's elevation, create or fill in a trench, erect or flatten a wall, or form a pillar. The extent of any such changes can't exceed half the area's largest dimension. So, if you affect a 40-foot square, you can create a pillar up to 20 feet high, raise or lower the square's elevation by up to 20 feet, dig a trench up to 20 feet deep, and so on. It takes 10 minutes for these changes to complete.
 	At the end of every 10 minutes you spend concentrating on the spell, you can choose a new area of terrain to affect.
 	Because the terrain's transformation occurs slowly, creatures in the area can't usually be trapped or injured by the ground's movement.
@@ -4556,7 +4556,7 @@ Source:	Player's Handbook (2014) p. 264</text>
     <range>30 feet</range>
     <components>V, S, M (a pinch of sesame seeds)</components>
     <duration>1 hour</duration>
-    <classes>School: Transformation, Wizard, Druid (Mountain)</classes>
+    <classes>School: Transmutation, Wizard, Druid (Mountain)</classes>
     <text>A passage appears at a point of your choice that you can see on a wooden, plaster, or stone surface (such as a wall, a ceiling, or a floor) within range, and lasts for the duration. You choose the opening's dimensions: up to 5 feet wide, 8 feet tall, and 20 feet deep. The passage creates no instability in a structure surrounding it.
 	When the opening disappears, any creatures or objects still in the passage created by the spell are safely ejected to an unoccupied space nearest to the surface on which you cast the spell.
 
@@ -4674,7 +4674,7 @@ Source:	Player's Handbook (2014) p. 266</text>
     <range>150 feet</range>
     <components>V, S</components>
     <duration>Instantaneous</duration>
-    <classes>School: Transformation, Bard, Druid, Ranger, Cleric (Nature), Druid (Forest), Paladin (Ancients), Warlock (Archfey)</classes>
+    <classes>School: Transmutation, Bard, Druid, Ranger, Cleric (Nature), Druid (Forest), Paladin (Ancients), Warlock (Archfey)</classes>
     <text>This spell channels vitality into plants within a specific area. There are two possible uses for the spell, granting either immediate or long-term benefits.
 	If you cast this spell using 1 action, choose a point within range. All normal plants in a 100-foot radius centered on that point become thick and overgrown. A creature moving through the area must spend 4 feet of movement for every 1 foot it moves.
 	You can exclude one or more areas of any size within the spell's area from being affected.
@@ -4709,7 +4709,7 @@ Source:	Player's Handbook (2014) p. 266</text>
     <range>60 feet</range>
     <components>V, S, M (a caterpillar cocoon)</components>
     <duration>Concentration, up to 1 hour</duration>
-    <classes>School: Transformation, Bard, Druid, Sorcerer, Wizard, Cleric (Trickery)</classes>
+    <classes>School: Transmutation, Bard, Druid, Sorcerer, Wizard, Cleric (Trickery)</classes>
     <text>This spell transforms a creature that you can see within range into a new form. An unwilling creature must make a Wisdom saving throw to avoid the effect. The spell has no effect on a shapechanger or a creature with 0 hit points.
 	The transformation lasts for the duration, or until the target drops to 0 hit points or dies. The new form can be any beast whose challenge rating is equal to or less than the target's (or the target's level, if it doesn't have a challenge rating). The target's game statistics, including mental ability scores, are replaced by the statistics of the chosen beast. It retains its alignment and personality.
 	The target assumes the hit points of its new form. When it reverts to its normal form, the creature returns to the number of hit points it had before it transformed. If it reverts as a result of dropping to 0 hit points, any excess damage carries over to its normal form. As long as the excess damage doesn't reduce the creature's normal form to 0 hit points, it isn't knocked unconscious.
@@ -4794,7 +4794,7 @@ Source:	Player's Handbook (2014) p. 267</text>
     <range>10 feet</range>
     <components>V, S</components>
     <duration>1 hour</duration>
-    <classes>School: Transformation, Fighter (Eldritch Knight), Rogue (Arcane Trickster), Bard, Sorcerer, Warlock, Wizard</classes>
+    <classes>School: Transmutation, Fighter (Eldritch Knight), Rogue (Arcane Trickster), Bard, Sorcerer, Warlock, Wizard</classes>
     <text>This spell is a minor magical trick that novice spellcasters use for practice. You create one of the following magical effects within range:
 
 	• You create an instantaneous, harmless sensory effect, such as a shower of sparks, a puff of wind, faint musical notes, or an odd odor.
@@ -5013,7 +5013,7 @@ Source:	Player's Handbook (2014) p. 270</text>
     <range>10 feet</range>
     <components>V, S</components>
     <duration>Instantaneous</duration>
-    <classes>School: Transformation, Cleric, Druid, Paladin</classes>
+    <classes>School: Transmutation, Cleric, Druid, Paladin</classes>
     <text>All nonmagical food and drink within a 5-foot-radius sphere centered on a point of your choice within range is purified and rendered free of poison and disease.
 
 Source:	Player's Handbook (2014) p. 270</text>
@@ -5118,7 +5118,7 @@ Source:	Player's Handbook (2014) p. 271</text>
     <range>Touch</range>
     <components>V, S, M (a prayer wheel and holy water)</components>
     <duration>1 hour</duration>
-    <classes>School: Transformation, Bard, Cleric, Druid</classes>
+    <classes>School: Transmutation, Bard, Cleric, Druid</classes>
     <text>You touch a creature and stimulate its natural healing ability. The target regains 4d8 + 15 hit points. For the duration of the spell, the target regains 1 hit point at the start of each of its turns (10 hit points each minute).
 	The target's severed body members (fingers, legs, tails, and so on), if any, are restored after 2 minutes. If you have the severed part and hold it to the stump, the spell instantaneously causes the limb to knit to the stump.
 
@@ -5133,7 +5133,7 @@ Source:	Player's Handbook (2014) p. 271</text>
     <range>Touch</range>
     <components>V, S, M (rare oils and unguents worth at least 1,000 gp, which the spell consumes)</components>
     <duration>Instantaneous</duration>
-    <classes>School: Transformation, Druid</classes>
+    <classes>School: Transmutation, Druid</classes>
     <text>You touch a dead humanoid or a piece of a dead humanoid. Provided that the creature has been dead no longer than 10 days, the spell forms a new adult body for it and then calls the soul to enter that body. If the target's soul isn't free or willing to do so, the spell fails.
 	The magic fashions a new body for the creature to inhabit, which likely causes the creature's race to change. The DM rolls a d100 and consults the following table to determine what form the creature takes when restored to life, or the DM chooses a form.
 
@@ -5211,7 +5211,7 @@ Source:	Player's Handbook (2014) p. 272</text>
     <range>100 feet</range>
     <components>V, S, M (a lodestone and iron filings)</components>
     <duration>Concentration, up to 1 minute</duration>
-    <classes>School: Transformation, Druid, Sorcerer, Wizard</classes>
+    <classes>School: Transmutation, Druid, Sorcerer, Wizard</classes>
     <text>This spell reverses gravity in a 50-foot-radius, 100-foot-high cylinder centered on a point within range. All creatures and objects that aren't somehow anchored to the ground in the area fall upward and reach the top of the area when you cast this spell. A creature can make a Dexterity saving throw to grab onto a fixed object it can reach, thus avoiding the fall.
 	If some solid object (such as a ceiling) is encountered in this fall, falling objects and creatures strike it just as they would during a normal downward fall. If an object or creature reaches the top of the area without striking anything, it remains there, oscillating slightly, for the duration.
 	At the end of the duration, affected objects and creatures fall back down.
@@ -5239,7 +5239,7 @@ Source:	Player's Handbook (2014) p. 272</text>
     <range>Touch</range>
     <components>V, S, M (powdered corn extract and a twisted loop of parchment)</components>
     <duration>1 hour</duration>
-    <classes>School: Transformation, Wizard</classes>
+    <classes>School: Transmutation, Wizard</classes>
     <text>You touch a length of rope that is up to 60 feet long. One end of the rope then rises into the air until the whole rope hangs perpendicular to the ground. At the upper end of the rope, an invisible entrance opens to an extradimensional space that lasts until the spell ends.
 	The extradimensional space can be reached by climbing to the top of the rope. The space can hold as many as eight Medium or smaller creatures. The rope can be pulled into the space, making the rope disappear from view outside the space.
 	Attacks and spells can't cross through the entrance into or out of the extradimensional space, but those inside can see out of it as if through a 3-foot-by-5-foot window centered on the rope.
@@ -5402,7 +5402,7 @@ Source:	Player's Handbook (2014) p. 274</text>
     <range>Touch</range>
     <components>V, S, M (a powder composed of diamond, emerald, ruby, and sapphire dust worth at least 5,000 gp, which the spell consumes)</components>
     <duration>Until dispelled</duration>
-    <classes>School: Transformation, Wizard</classes>
+    <classes>School: Transmutation, Wizard</classes>
     <text>By means of this spell, a willing creature or an object can be hidden away, safe from detection for the duration. When you cast the spell and touch the target, it becomes invisible and can't be targeted by divination spells or perceived through scrying sensors created by divination spells.
 	If the target is a creature, it falls into a state of suspended animation. Time ceases to flow for it, and it doesn't grow older.
 	You can set a condition for the spell to end early. The condition can be anything you choose, but it must occur or be visible within 1 mile of the target. Examples include "after 1,000 years" or "when the tarrasque awakens." This spell also ends if the target takes any damage.
@@ -5421,7 +5421,7 @@ Source:	Player's Handbook (2014) p. 274</text>
     <range>Self</range>
     <components>V, S, M (a jade circlet worth at least 1,500 gp, which you must place on your head before you cast the spell)</components>
     <duration>Concentration, up to 1 hour</duration>
-    <classes>School: Transformation, Druid, Wizard</classes>
+    <classes>School: Transmutation, Druid, Wizard</classes>
     <text>You assume the form of a different creature for the duration. The new form can be of any creature with a challenge rating equal to your level or lower. The creature can't be a construct or an undead, and you must have seen the sort of creature at least once. You transform into an average example of that creature, one without any class levels or the Spellcasting trait.
 	Your game statistics are replaced by the statistics of the chosen creature, though you retain your alignment and Intelligence, Wisdom, and Charisma scores. You also retain all of your skill and saving throw proficiencies, in addition to gaining those of the creature. If the creature has the same proficiency as you and the bonus listed in its statistics is higher than yours, use the creature's bonus in place of yours. You can't use any legendary actions or lair actions of the new form.
 	You assume the hit points and Hit Dice of the new form. When you revert to your normal form, you return to the number of hit points you had before you transformed. If you revert as a result of dropping to 0 hit points, any excess damage carries over to your normal form. As long as the excess damage doesn't reduce your normal form to 0 hit points, you aren't knocked unconscious.
@@ -5490,7 +5490,7 @@ Source:	Player's Handbook (2014) p. 275</text>
     <range>Touch</range>
     <components>V, S, M (mistletoe, a shamrock leaf, and a club or quarterstaff)</components>
     <duration>1 minute</duration>
-    <classes>School: Transformation, Druid</classes>
+    <classes>School: Transmutation, Druid</classes>
     <text>The wood of a club or quarterstaff you are holding is imbued with nature's power. For the duration, you can use your spellcasting ability instead of Strength for the attack and damage rolls of melee attacks using that weapon, and the weapon's damage die becomes a d8. The weapon also becomes magical, if it isn't already. The spell ends if you cast it again or if you let go of the weapon.
 
 Source:	Player's Handbook (2014) p. 275</text>
@@ -5618,7 +5618,7 @@ Source:	Player's Handbook (2014) p. 276</text>
     <range>120 feet</range>
     <components>V, S, M (a drop of molasses)</components>
     <duration>Concentration, up to 1 minute</duration>
-    <classes>School: Transformation, Sorcerer, Wizard, Druid (Arctic)</classes>
+    <classes>School: Transmutation, Sorcerer, Wizard, Druid (Arctic)</classes>
     <text>You alter time around up to six creatures of your choice in a 40-foot cube within range. Each target must succeed on a Wisdom saving throw or be affected by this spell for the duration.
 	An affected target's speed is halved, it takes a −2 penalty to AC and Dexterity saving throws, and it can't use reactions. On its turn, it can use either an action or a bonus action, not both. Regardless of the creature's abilities or magic items, it can't make more than one melee or ranged attack during its turn.
 	If the creature attempts to cast a spell with a casting time of 1 action, roll a d20. On an 11 or higher, the spell doesn't take effect until the creature's next turn, and the creature must use its action on that turn to complete the spell. If it can't, the spell is wasted.
@@ -5675,7 +5675,7 @@ Source:	Player's Handbook (2014) p. 277</text>
     <range>Self (30-foot radius)</range>
     <components>V, S</components>
     <duration>10 minutes</duration>
-    <classes>School: Transformation, Bard, Druid, Ranger</classes>
+    <classes>School: Transmutation, Bard, Druid, Ranger</classes>
     <text>You imbue plants within 30 feet of you with limited sentience and animation, giving them the ability to communicate with you and follow your simple commands. You can question plants about events in the spell's area within the past day, gaining information about creatures that have passed, weather, and other circumstances.
 	You can also turn difficult terrain caused by plant growth (such as thickets and undergrowth) into ordinary terrain that lasts for the duration. Or you can turn ordinary terrain where plants are present into difficult terrain that lasts for the duration, causing vines and branches to hinder pursuers, for example.
 	Plants might be able to perform other tasks on your behalf, at the DM's discretion. The spell doesn't enable plants to uproot themselves and move about, but they can freely move branches, tendrils, and stalks.
@@ -5692,7 +5692,7 @@ Source:	Player's Handbook (2014) p. 277</text>
     <range>Touch</range>
     <components>V, S, M (a drop of bitumen and a spider)</components>
     <duration>Concentration, up to 1 hour</duration>
-    <classes>School: Transformation, Sorcerer, Warlock, Wizard, Druid (Forest), Druid (Mountain), Druid (Underdark)</classes>
+    <classes>School: Transmutation, Sorcerer, Warlock, Wizard, Druid (Forest), Druid (Mountain), Druid (Underdark)</classes>
     <text>Until the spell ends, one willing creature you touch gains the ability to move up, down, and across vertical surfaces and upside down along ceilings, while leaving its hands free. The target also gains a climbing speed equal to its walking speed.
 
 Source:	Player's Handbook (2014) p. 277</text>
@@ -5705,7 +5705,7 @@ Source:	Player's Handbook (2014) p. 277</text>
     <range>150 feet</range>
     <components>V, S, M (seven sharp thorns or seven small twigs, each sharpened to a point)</components>
     <duration>Concentration, up to 10 minutes</duration>
-    <classes>School: Transformation, Druid, Ranger, Cleric (Nature), Druid (Arctic), Druid (Mountain)</classes>
+    <classes>School: Transmutation, Druid, Ranger, Cleric (Nature), Druid (Arctic), Druid (Mountain)</classes>
     <text>The ground in a 20-foot radius centered on a point within range twists and sprouts hard spikes and thorns. The area becomes difficult terrain for the duration. When a creature moves into or within the area, it takes 2d4 piercing damage for every 5 feet it travels.
 	The transformation of the ground is camouflaged to look natural. Any creature that can't see the area at the time the spell is cast must make a Wisdom (Perception) check against your spell save DC to recognize the terrain as hazardous before entering it.
 
@@ -5787,7 +5787,7 @@ Source:	Player's Handbook (2014) p. 278</text>
     <range>Touch</range>
     <components>V, S, M (soft clay, which must be worked into roughly the desired shape of the stone object)</components>
     <duration>Instantaneous</duration>
-    <classes>School: Transformation, Cleric, Druid, Wizard, Druid (Mountain), Druid (Underdark)</classes>
+    <classes>School: Transmutation, Cleric, Druid, Wizard, Druid (Mountain), Druid (Underdark)</classes>
     <text>You touch a stone object of Medium size or smaller or a section of stone no more than 5 feet in any dimension and form it into any shape that suits your purpose. So, for example, you could shape a large rock into a weapon, idol, or coffer, or make a small passage through a wall, as long as the wall is less than 5 feet thick. You could also shape a stone door or its frame to seal the door shut. The object you create can have up to two hinges and a latch, but finer mechanical detail isn't possible.
 
 Source:	Player's Handbook (2014) p. 278</text>
@@ -5899,7 +5899,7 @@ Source:	Player's Handbook (2014) p. 279</text>
     <range>Touch</range>
     <components>V, S, M (a quiver containing at least one piece of ammunition)</components>
     <duration>Concentration, up to 1 minute</duration>
-    <classes>School: Transformation, Ranger</classes>
+    <classes>School: Transmutation, Ranger</classes>
     <text>You transmute your quiver so it produces an endless supply of nonmagical ammunition, which seems to leap into your hand when you reach for it.
 	On each of your turns until the spell ends, you can use a bonus action to make two attacks with a weapon that uses ammunition from the quiver. Each time you make such a ranged attack, your quiver magically replaces the piece of ammunition you used with a similar piece of nonmagical ammunition. Any pieces of ammunition created by this spell disintegrate when the spell ends. If the quiver leaves your possession, the spell ends.
 
@@ -5969,7 +5969,7 @@ Source:	Player's Handbook (2014) p. 280</text>
     <range>60 feet</range>
     <components>V, S</components>
     <duration>Concentration, up to 10 minutes</duration>
-    <classes>School: Transformation, Sorcerer, Wizard, Warlock (Great Old One)</classes>
+    <classes>School: Transmutation, Sorcerer, Wizard, Warlock (Great Old One)</classes>
     <text>You gain the ability to move or manipulate creatures or objects by thought. When you cast the spell, and as your action each round for the duration, you can exert your will on one creature or object that you can see within range, causing the appropriate effect below. You can affect the same target round after round, or choose a new one at any time. If you switch targets, the prior target is no longer affected by the spell.
 
 Creature: You can try to move a Huge or smaller creature. Make an ability check with your spellcasting ability contested by the creature's Strength check. If you win the contest, you move the creature up to 30 feet in any direction, including upward but not beyond the range of this spell. Until the end of your next turn, the creature is restrained in your telekinetic grip. A creature lifted upward is suspended in mid-air.
@@ -6080,7 +6080,7 @@ Source:	Player's Handbook (2014) p. 282</text>
     <range>30 feet</range>
     <components>V</components>
     <duration>1 minute</duration>
-    <classes>School: Transformation, Cleric</classes>
+    <classes>School: Transmutation, Cleric</classes>
     <text>You manifest a minor wonder, a sign of supernatural power, within range. You create one of the following magical effects within range:
 
 	• Your voice booms up to three times as loud as normal for 1 minute.
@@ -6107,7 +6107,7 @@ Source:	Player's Handbook (2014) p. 282</text>
     <range>30 feet</range>
     <components>V, S, M (the stem of a plant with thorns)</components>
     <duration>Instantaneous</duration>
-    <classes>School: Transformation, Druid</classes>
+    <classes>School: Transmutation, Druid</classes>
     <text>You create a long, vine-like whip covered in thorns that lashes out at your command toward a creature in range. Make a melee spell attack against the target. If the attack hits, the creature takes 1d6 piercing damage, and if the creature is Large or smaller, you pull the creature up to 10 feet closer to you.
 
 Cantrip Upgrade: This spell's damage increases by 1d6 when you reach 5th level (2d6), 11th level (3d6), and 17th level (4d6).
@@ -6171,7 +6171,7 @@ Source:	Player's Handbook (2014) p. 282</text>
     <range>Self</range>
     <components>V</components>
     <duration>Instantaneous</duration>
-    <classes>School: Transformation, Sorcerer, Wizard</classes>
+    <classes>School: Transmutation, Sorcerer, Wizard</classes>
     <text>You briefly stop the flow of time for everyone but yourself. No time passes for other creatures, while you take 1d4 + 1 turns in a row, during which you can use actions and move as normal.
 	This spell ends if one of the actions you use during this period, or any effects that you create during this period, affects a creature other than you or an object being worn or carried by someone other than you. In addition, the spell ends if you move to a place more than 1,000 feet from the location where you cast it.
 
@@ -6226,7 +6226,7 @@ Source:	Player's Handbook (2014) p. 283</text>
     <range>30 feet</range>
     <components>V, S, M (a drop of mercury, a dollop of gum arabic, and a wisp of smoke)</components>
     <duration>Concentration, up to 1 hour</duration>
-    <classes>School: Transformation, Bard, Warlock, Wizard</classes>
+    <classes>School: Transmutation, Bard, Warlock, Wizard</classes>
     <text>Choose one creature or nonmagical object that you can see within range. You transform the creature into a different creature, the creature into a nonmagical object, or the object into a creature (the object must be neither worn nor carried by another creature). The transformation lasts for the duration, or until the target drops to 0 hit points or dies. If you concentrate on this spell for the full duration, the transformation lasts until it is dispelled.
 	This spell has no effect on a shapechanger or a creature with 0 hit points. An unwilling creature can make a Wisdom saving throw, and if it succeeds, it isn't affected by this spell.
 
@@ -6488,7 +6488,7 @@ Source:	Player's Handbook (2014) p. 287</text>
     <range>30 feet</range>
     <components>V, S, M (a short reed or piece of straw)</components>
     <duration>24 hours</duration>
-    <classes>School: Transformation, Druid, Ranger, Sorcerer, Wizard, Druid (Coast)</classes>
+    <classes>School: Transmutation, Druid, Ranger, Sorcerer, Wizard, Druid (Coast)</classes>
     <text>This spell grants up to ten willing creatures you can see within range the ability to breathe underwater until the spell ends. Affected creatures also retain their normal mode of respiration.
 
 Source:	Player's Handbook (2014) p. 287</text>
@@ -6502,7 +6502,7 @@ Source:	Player's Handbook (2014) p. 287</text>
     <range>30 feet</range>
     <components>V, S, M (a piece of cork)</components>
     <duration>1 hour</duration>
-    <classes>School: Transformation, Cleric, Druid, Ranger, Sorcerer, Druid (Coast), Druid (Swamp)</classes>
+    <classes>School: Transmutation, Cleric, Druid, Ranger, Sorcerer, Druid (Coast), Druid (Swamp)</classes>
     <text>This spell grants the ability to move across any liquid surface—such as water, acid, mud, snow, quicksand, or lava—as if it were harmless solid ground (creatures crossing molten lava can still take damage from the heat). Up to ten willing creatures you can see within range gain this ability for the duration.
 	If you target a creature submerged in a liquid, the spell carries the target to the surface of the liquid at a rate of 60 feet per round.
 
@@ -6553,7 +6553,7 @@ Source:	Player's Handbook (2014) p. 288</text>
     <range>30 feet</range>
     <components>V, S, M (fire and holy water)</components>
     <duration>8 hours</duration>
-    <classes>School: Transformation, Druid</classes>
+    <classes>School: Transmutation, Druid</classes>
     <text>You and up to ten willing creatures you can see within range assume a gaseous form for the duration, appearing as wisps of cloud. While in this cloud form, a creature has a flying speed of 300 feet and has resistance to damage from nonmagical weapons. The only actions a creature can take in this form are the Dash action or to revert to its normal form. Reverting takes 1 minute, during which time a creature is incapacitated and can't move. Until the spell ends, a creature can revert to cloud form, which also requires the 1-minute transformation.
 	If a creature is in cloud form and flying when the effect ends, the creature descends 60 feet per round for 1 minute until it lands, which it does safely. If it can't land after 1 minute, the creature falls the remaining distance.
 

--- a/Sources/WizardsOfTheCoast/Spelljammer_Adventures_in_Space/spells-ais.xml
+++ b/Sources/WizardsOfTheCoast/Spelljammer_Adventures_in_Space/spells-ais.xml
@@ -23,7 +23,7 @@ Source:	Spelljammer: Adventures in Space - Astral Adventurer's Guide p. 22</text
     <range>Touch</range>
     <components>V, S, M (a crystal rod worth at least 5,000 gp, which the spell consumes)</components>
     <duration>Instantaneous</duration>
-    <classes>School: Transformation, Artificer, Wizard</classes>
+    <classes>School: Transmutation, Artificer, Wizard</classes>
     <text>Holding the rod used in the casting of the spell, you touch a Large or smaller chair that is unoccupied. The rod disappears, and the chair is transformed into a spelljamming helm.
 
 Source:	Spelljammer: Adventures in Space - Astral Adventurer's Guide p. 22</text>

--- a/Sources/WizardsOfTheCoast/Tashas_Cauldron_of_Everything/spells-tce.xml
+++ b/Sources/WizardsOfTheCoast/Tashas_Cauldron_of_Everything/spells-tce.xml
@@ -365,7 +365,7 @@ Source:	Tasha's Cauldron of Everything p. 115</text>
     <range>Self</range>
     <components>V, S, M (an object engraved with a symbol of the Outer Planes, worth at least 500 gp)</components>
     <duration>Concentration, up to 1 minute</duration>
-    <classes>School: Transformation, Sorcerer, Warlock, Wizard</classes>
+    <classes>School: Transmutation, Sorcerer, Warlock, Wizard</classes>
     <text>Uttering an incantation, you draw on the magic of the Lower Planes or Upper Planes (your choice) to transform yourself. You gain the following benefits until the spell ends:
 
 	• You are immune to fire and poison damage (Lower Planes) or radiant and necrotic damage (Upper Planes).

--- a/Sources/WizardsOfTheCoast/Xanathars_Guide_to_Everything/spells-xge.xml
+++ b/Sources/WizardsOfTheCoast/Xanathars_Guide_to_Everything/spells-xge.xml
@@ -87,7 +87,7 @@ Source:	Xanathar's Guide to Everything p. 150,
     <range>120 feet</range>
     <components>V, S</components>
     <duration>Instantaneous</duration>
-    <classes>School: Transformation, Druid</classes>
+    <classes>School: Transmutation, Druid</classes>
     <text>You cause up to six pillars of stone to burst from places on the ground that you can see within range. Each pillar is a cylinder that has a diameter of 5 feet and a height of up to 30 feet. The ground where a pillar appears must be wide enough for its diameter, and you can target the ground under a creature if that creature is Medium or smaller. Each pillar has AC 5 and 30 hit points. When reduced to 0 hit points, a pillar crumbles into rubble, which creates an area of difficult terrain with a 10-foot radius that lasts until the rubble is cleared. Each 5-foot-diameter portion of the area requires at least 1 minute to clear by hand.
 	If a pillar is created under a creature, that creature must succeed on a Dexterity saving throw or be lifted by the pillar. A creature can choose to fail the save.
 	If a pillar is prevented from reaching its full height because of a ceiling or other obstacle, a creature on the pillar takes 6d6 bludgeoning damage and is restrained, pinched between the pillar and the obstacle. The restrained creature can use an action to make a Strength or Dexterity check (the creature's choice) against the spell's save DC. On a success, the creature is no longer restrained and must either move off the pillar or fall off it.
@@ -111,7 +111,7 @@ Source:	Xanathar's Guide to Everything p. 150,
     <range>60 feet</range>
     <components>S</components>
     <duration>Instantaneous</duration>
-    <classes>School: Transformation, Sorcerer, Wizard</classes>
+    <classes>School: Transmutation, Sorcerer, Wizard</classes>
     <text>Choose one object weighing 1 to 5 pounds within range that isn't being worn or carried. The object flies in a straight line up to 90 feet in a direction you choose before falling to the ground, stopping early if it impacts against a solid surface. If the object would strike a creature, that creature must make a Dexterity saving throw. On a failed save, the object strikes the target and stops moving. When the object strikes something, the object and what it strikes each take 3d8 bludgeoning damage.
 
 At Higher Levels: When you cast this spell using a spell slot of 2nd level or higher, the maximum weight of objects that you can target with this spell increases by 5 pounds, and the damage increases by 1d8, for each slot level above 1st.
@@ -251,7 +251,7 @@ Source:	Xanathar's Guide to Everything p. 151</text>
     <range>60 feet</range>
     <components>S</components>
     <duration>Instantaneous, 1 hour</duration>
-    <classes>School: Transformation, Fighter (Eldritch Knight), Rogue (Arcane Trickster), Druid, Sorcerer, Wizard</classes>
+    <classes>School: Transmutation, Fighter (Eldritch Knight), Rogue (Arcane Trickster), Druid, Sorcerer, Wizard</classes>
     <text>You choose nonmagical flame that you can see within range and that fits within a 5-foot cube. You affect it in one of the following ways:
 
 	• You instantaneously expand the flame 5 feet in one direction, provided that wood or other fuel is present in the new location.
@@ -275,7 +275,7 @@ Source:	Xanathar's Guide to Everything p. 152,
     <range>300 feet</range>
     <components>V, S</components>
     <duration>Concentration, up to 1 hour</duration>
-    <classes>School: Transformation, Druid, Sorcerer, Wizard</classes>
+    <classes>School: Transmutation, Druid, Sorcerer, Wizard</classes>
     <text>You take control of the air in a 100-foot cube that you can see within range. Choose one of the following effects when you cast the spell. The effect lasts for the spell's duration, unless you use your action on a later turn to switch to a different effect. You can also use your action to temporarily halt the effect or to restart one you've halted.
 
 Gusts: A wind picks up within the cube, continually blowing in a horizontal direction you designate. You choose the intensity of the wind: calm, moderate, or strong. If the wind is moderate or strong, ranged weapon attacks that pass through it or that are made against targets within the cube have disadvantage on their attack rolls. If the wind is strong, any creature moving against the wind must spend 1 extra foot of movement for each foot moved.
@@ -321,7 +321,7 @@ Source:	Xanathar's Guide to Everything p. 152,
     <range>Touch</range>
     <components>V, S, M (clay, ash, and mandrake root, all of which the spell consumes, and a jewel-encrusted dagger worth at least 1,000 gp)</components>
     <duration>Instantaneous</duration>
-    <classes>School: Transformation, Wizard</classes>
+    <classes>School: Transmutation, Wizard</classes>
     <text>While speaking an intricate incantation, you cut yourself with a jewel-encrusted dagger, taking 2d4 piercing damage that can't be reduced in any way. You then drip your blood on the spell's other components and touch them, transforming them into a special construct called a homunculus.
 	The statistics of the homunculus are in the Monster Manual. It is your faithful companion, and it dies if you die. Whenever you finish a long rest, you can spend up to half your Hit Dice if the homunculus is on the same plane of existence as you. When you do so, roll each die and add your Constitution modifier to it. Your hit point maximum is reduced by the total, and the homunculus's hit point maximum and current hit points are both increased by it. This process can reduce you to no lower than 1 hit point, and the change to your and the homunculus's hit points ends when you finish your next long rest. The reduction to your hit point maximum can't be removed by any means before then, except by the homunculus's death.
 	You can have only one homunculus at a time. If you cast this spell while your homunculus lives, the spell fails.
@@ -387,7 +387,7 @@ Source:	Xanathar's Guide to Everything p. 153</text>
     <range>Touch</range>
     <components>V, S, M (a hot pepper)</components>
     <duration>Concentration, up to 1 minute</duration>
-    <classes>School: Transformation, Sorcerer, Wizard</classes>
+    <classes>School: Transmutation, Sorcerer, Wizard</classes>
     <text>You touch one willing creature and imbue it with the power to spew magical energy from its mouth, provided it has one. Choose acid, cold, fire, lightning, or poison. Until the spell ends, the creature can use an action to exhale energy of the chosen type in a 15-foot cone. Each creature in that area must make a Dexterity saving throw, taking 3d6 damage of the chosen type on a failed save, or half as much damage on a successful one.
 
 At Higher Levels: When you cast this spell using a spell slot of 3rd level or higher, the damage increases by 1d6 for each slot level above 2nd.
@@ -495,7 +495,7 @@ Source:	Xanathar's Guide to Everything p. 155,
     <range>300 feet</range>
     <components>V</components>
     <duration>Concentration, up to 1 minute</duration>
-    <classes>School: Transformation, Druid, Sorcerer, Warlock, Wizard</classes>
+    <classes>School: Transmutation, Druid, Sorcerer, Warlock, Wizard</classes>
     <text>Choose one creature you can see within range. Yellow strips of magical energy loop around the creature. The target must succeed on a Strength saving throw, or its flying speed (if any) is reduced to 0 feet for the spell's duration. An airborne creature affected by this spell safely descends at 60 feet per round until it reaches the ground or the spell ends.
 
 Source:	Xanathar's Guide to Everything p. 154,
@@ -509,7 +509,7 @@ Source:	Xanathar's Guide to Everything p. 154,
     <range>90 feet</range>
     <components>V, S</components>
     <duration>Concentration, up to 1 minute</duration>
-    <classes>School: Transformation, Druid, Warlock, Wizard</classes>
+    <classes>School: Transmutation, Druid, Warlock, Wizard</classes>
     <text>Choose one creature you can see within range, and choose one of the following damage types: acid, cold, fire, lightning, or thunder. The target must succeed on a Constitution saving throw or be affected by the spell for its duration. The first time each turn the affected target takes damage of the chosen type, the target takes an extra 2d6 damage of that type. Moreover, the target loses any resistance to that damage type until the spell ends.
 
 At Higher Levels: When you cast this spell using a spell slot of 5th level or higher, you can target one additional creature for each slot level above 4th. The creatures must be within 30 feet of each other when you target them.
@@ -562,7 +562,7 @@ Source:	Xanathar's Guide to Everything p. 155</text>
     <range>120 feet</range>
     <components>V, S, M (a piece of obsidian)</components>
     <duration>Instantaneous</duration>
-    <classes>School: Transformation, Druid, Sorcerer, Wizard</classes>
+    <classes>School: Transmutation, Druid, Sorcerer, Wizard</classes>
     <text>Choose a point you can see on the ground within range. A fountain of churned earth and stone erupts in a 20-foot cube centered on that point. Each creature in that area must make a Dexterity saving throw. A creature takes 3d12 bludgeoning damage on a failed save, or half as much damage on a successful one. Additionally, the ground in that area becomes difficult terrain until cleared. Each 5-foot-square portion of the area requires at least 1 minute to clear by hand.
 
 At Higher Levels: When you cast this spell using a spell slot of 4th level or higher, the damage increases by 1d12 for each slot level above 3rd.
@@ -615,7 +615,7 @@ Source:	Xanathar's Guide to Everything p. 156</text>
     <range>Touch</range>
     <components>V, S</components>
     <duration>Concentration, up to 1 hour</duration>
-    <classes>School: Transformation, Druid, Ranger, Sorcerer, Wizard</classes>
+    <classes>School: Transmutation, Druid, Ranger, Sorcerer, Wizard</classes>
     <text>You touch a quiver containing arrows or bolts. When a target is hit by a ranged weapon attack using a piece of ammunition drawn from the quiver, the target takes an extra 1d6 fire damage. The spell's magic ends on a piece of ammunition when it hits or misses, and the spell ends when twelve pieces of ammunition have been drawn from the quiver.
 
 At Higher Levels: When you cast this spell using a spell slot of 4th level or higher, the number of pieces of ammunition you can affect with this spell increases by two for each slot level above 3rd.
@@ -652,7 +652,7 @@ Source:	Xanathar's Guide to Everything p. 156,
     <range>Self</range>
     <components>V</components>
     <duration>Concentration, up to 1 minute</duration>
-    <classes>School: Transformation, Druid, Ranger</classes>
+    <classes>School: Transmutation, Druid, Ranger</classes>
     <text>A nature spirit answers your call and transforms you into a powerful guardian. The transformation lasts until the spell ends. You choose one of the following forms to assume: Primal Beast or Great Tree.
 
 Primal Beast: Bestial fur covers your body, your facial features become feral, and you gain the following benefits:
@@ -680,7 +680,7 @@ Source:	Xanathar's Guide to Everything p. 157</text>
     <range>30 feet</range>
     <components>V, S</components>
     <duration>Instantaneous</duration>
-    <classes>School: Transformation, Fighter (Eldritch Knight), Rogue (Arcane Trickster), Druid, Sorcerer, Wizard</classes>
+    <classes>School: Transmutation, Fighter (Eldritch Knight), Rogue (Arcane Trickster), Druid, Sorcerer, Wizard</classes>
     <text>You seize the air and compel it to create one of the following effects at a point you can see within range:
 
 	• One Medium or smaller creature that you choose must succeed on a Strength saving throw or be pushed up to 5 feet away from you.
@@ -848,7 +848,7 @@ Source:	Xanathar's Guide to Everything p. 158</text>
     <range>Self</range>
     <components>V, S</components>
     <duration>Concentration, up to 10 minutes</duration>
-    <classes>School: Transformation, Druid, Sorcerer, Warlock, Wizard</classes>
+    <classes>School: Transmutation, Druid, Sorcerer, Warlock, Wizard</classes>
     <text>Flames race across your body, shedding bright light in a 30-foot radius and dim light for an additional 30 feet for the spell's duration. The flames don't harm you. Until the spell ends, you gain the following benefits:
 
 	• You are immune to fire damage and have resistance to cold damage.
@@ -870,7 +870,7 @@ Source:	Xanathar's Guide to Everything p. 159,
     <range>Self</range>
     <components>V, S</components>
     <duration>Concentration, up to 10 minutes</duration>
-    <classes>School: Transformation, Druid, Sorcerer, Warlock, Wizard</classes>
+    <classes>School: Transmutation, Druid, Sorcerer, Warlock, Wizard</classes>
     <text>Until the spell ends, ice rimes your body, and you gain the following benefits:
 
 	• You are immune to cold damage and have resistance to fire damage.
@@ -893,7 +893,7 @@ Source:	Xanathar's Guide to Everything p. 159,
     <range>Self</range>
     <components>V, S</components>
     <duration>Concentration, up to 10 minutes</duration>
-    <classes>School: Transformation, Druid, Sorcerer, Warlock, Wizard</classes>
+    <classes>School: Transmutation, Druid, Sorcerer, Warlock, Wizard</classes>
     <text>Until the spell ends, bits of rock spread across your body, and you gain the following benefits:
 
 	• You have resistance to bludgeoning, piercing, and slashing damage from nonmagical attacks.
@@ -923,7 +923,7 @@ Source:	Xanathar's Guide to Everything p. 159,
     <range>Self</range>
     <components>V, S</components>
     <duration>Concentration, up to 10 minutes</duration>
-    <classes>School: Transformation, Druid, Sorcerer, Warlock, Wizard</classes>
+    <classes>School: Transmutation, Druid, Sorcerer, Warlock, Wizard</classes>
     <text>Until the spell ends, wind whirls around you, and you gain the following benefits:
 
 	• Ranged weapon attacks made against you have disadvantage on the attack roll.
@@ -1009,7 +1009,7 @@ Source:	Xanathar's Guide to Everything p. 160,
     <range>Touch</range>
     <components>V, S</components>
     <duration>1 minute</duration>
-    <classes>School: Transformation, Druid, Warlock</classes>
+    <classes>School: Transmutation, Druid, Warlock</classes>
     <text>You touch one to three pebbles and imbue them with magic. You or someone else can make a ranged spell attack with one of the pebbles by throwing it or hurling it with a sling. If thrown, a pebble has a range of 60 feet. If someone else attacks with a pebble, that attacker adds your spellcasting ability modifier, not the attacker's, to the attack roll. On a hit, the target takes bludgeoning damage equal to 1d6 + your spellcasting ability modifier. Whether the attack hits or misses, the spell then ends on the stone.
 	If you cast this spell again, the spell ends on any pebbles still affected by your previous casting.
 
@@ -1025,7 +1025,7 @@ Source:	Xanathar's Guide to Everything p. 160,
     <range>120 feet</range>
     <components>V, S, M (a caterpillar cocoon)</components>
     <duration>Concentration, up to 1 hour</duration>
-    <classes>School: Transformation, Bard, Sorcerer, Wizard</classes>
+    <classes>School: Transmutation, Bard, Sorcerer, Wizard</classes>
     <text>You transform up to ten creatures of your choice that you can see within range. An unwilling target must succeed on a Wisdom saving throw to resist the transformation. An unwilling shapechanger automatically succeeds on the save.
 	Each target assumes a beast form of your choice, and you can choose the same form or different ones for each target. The new form can be any beast you have seen whose challenge rating is equal to or less than the target's (or half the target's level, if the target doesn't have a challenge rating). The target's game statistics, including mental ability scores, are replaced by the statistics of the chosen beast, but the target retains its hit points, alignment, and personality.
 	Each target gains a number of temporary hit points equal to the hit points of its new form. These temporary hit points can't be replaced by temporary hit points from another source. A target reverts to its normal form when it has no more temporary hit points or it dies. If the spell ends before then, the creature loses all its temporary hit points and reverts to its normal form.
@@ -1042,7 +1042,7 @@ Source:	Xanathar's Guide to Everything p. 160</text>
     <range>30 feet</range>
     <components>V, S, M (a miniature hand sculpted from clay)</components>
     <duration>Concentration, up to 1 minute</duration>
-    <classes>School: Transformation, Sorcerer, Wizard</classes>
+    <classes>School: Transmutation, Sorcerer, Wizard</classes>
     <text>You choose a 5-foot-square unoccupied space on the ground that you can see within range. A Medium hand made from compacted soil rises there and reaches for one creature you can see within 5 feet of it. The target must make a Strength saving throw. On a failed save, the target takes 2d6 bludgeoning damage and is restrained for the spell's duration.
 	As an action, you can cause the hand to crush the restrained target, which must make a Strength saving throw. The target takes 2d6 bludgeoning damage on a failed save, or half as much damage on a successful one.
 	To break out, the restrained target can use its action to make a Strength check against your spell save DC. On a success, the target escapes and is no longer restrained by the hand.
@@ -1144,7 +1144,7 @@ Source:	Xanathar's Guide to Everything p. 162</text>
     <range>30 feet</range>
     <components>S</components>
     <duration>Instantaneous, 1 hour</duration>
-    <classes>School: Transformation, Fighter (Eldritch Knight), Rogue (Arcane Trickster), Druid, Sorcerer, Wizard</classes>
+    <classes>School: Transmutation, Fighter (Eldritch Knight), Rogue (Arcane Trickster), Druid, Sorcerer, Wizard</classes>
     <text>You choose a portion of dirt or stone that you can see within range and that fits within a 5-foot cube. You manipulate it in one of the following ways:
 
 	• If you target an area of loose earth, you can instantaneously excavate it, move it along the ground, and deposit it up to 5 feet away. This movement doesn't involve enough force to cause damage.
@@ -1196,7 +1196,7 @@ Source:	Xanathar's Guide to Everything p. 163</text>
     <range>Self</range>
     <components>S</components>
     <duration>Instantaneous</duration>
-    <classes>School: Transformation, Druid</classes>
+    <classes>School: Transmutation, Druid</classes>
     <text>You channel primal magic to cause your teeth or fingernails to sharpen, ready to deliver a corrosive attack. Make a melee spell attack against one creature within 5 feet of you. On a hit, the target takes 1d10 acid damage. After you make the attack, your teeth or fingernails return to normal.
 
 Cantrip Upgrade: The spell's damage increases by 1d10 when you reach 5th level (2d10), 11th level (3d10), and 17th level (4d10).
@@ -1246,7 +1246,7 @@ Source:	Xanathar's Guide to Everything p. 163</text>
     <range>60 feet</range>
     <components>V, S</components>
     <duration>Instantaneous</duration>
-    <classes>School: Transformation, Bard, Sorcerer, Wizard</classes>
+    <classes>School: Transmutation, Bard, Sorcerer, Wizard</classes>
     <text>Choose an area of nonmagical flame that you can see and that fits within a 5-foot cube within range. You can extinguish the fire in that area, and you create either fireworks or smoke when you do so.
 
 Fireworks: The target explodes with a dazzling display of colors. Each creature within 10 feet of the target must succeed on a Constitution saving throw or become blinded until the end of your next turn.
@@ -1316,7 +1316,7 @@ Source:	Xanathar's Guide to Everything p. 164</text>
     <range>30 feet</range>
     <components>S</components>
     <duration>Instantaneous, 1 hour</duration>
-    <classes>School: Transformation, Fighter (Eldritch Knight), Rogue (Arcane Trickster), Druid, Sorcerer, Wizard</classes>
+    <classes>School: Transmutation, Fighter (Eldritch Knight), Rogue (Arcane Trickster), Druid, Sorcerer, Wizard</classes>
     <text>You choose an area of water that you can see within range and that fits within a 5-foot cube. You manipulate it in one of the following ways:
 
 	• You instantaneously move or otherwise change the flow of the water as you direct, up to 5 feet in any direction. This movement doesn't have enough force to cause damage.
@@ -1356,7 +1356,7 @@ Source:	Xanathar's Guide to Everything p. 164</text>
     <range>Touch</range>
     <components>V, S</components>
     <duration>Concentration, up to 1 hour</duration>
-    <classes>School: Transformation, Bard, Sorcerer, Wizard</classes>
+    <classes>School: Transmutation, Bard, Sorcerer, Wizard</classes>
     <text>Your magic deepens a creature's understanding of its own talent. You touch one willing creature and give it expertise in one skill of your choice; until the spell ends, the creature doubles its proficiency bonus for ability checks it makes that use the chosen skill.
 	You must choose a skill in which the target is proficient and that isn't already benefiting from an effect, such as Expertise, that doubles its proficiency bonus.
 
@@ -1371,7 +1371,7 @@ Source:	Xanathar's Guide to Everything p. 165</text>
     <range>Sight</range>
     <components>V, S</components>
     <duration>Concentration, up to 1 hour</duration>
-    <classes>School: Transformation, Bard, Druid, Wizard</classes>
+    <classes>School: Transmutation, Bard, Druid, Wizard</classes>
     <text>You cause up to ten words to form in a part of the sky you can see. The words appear to be made of cloud and remain in place for the spell's duration. The words dissipate when the spell ends. A strong wind can disperse the clouds and end the spell early.
 
 Source:	Xanathar's Guide to Everything p. 165,
@@ -1578,7 +1578,7 @@ Source:	Xanathar's Guide to Everything p. 167</text>
     <range>Self</range>
     <components>V, S, M (a few hairs from a bull)</components>
     <duration>Concentration, up to 10 minutes</duration>
-    <classes>School: Transformation, Wizard</classes>
+    <classes>School: Transmutation, Wizard</classes>
     <text>You endow yourself with endurance and martial prowess fueled by magic. Until the spell ends, you can't cast spells, and you gain the following benefits:
 
 	• You gain 50 temporary hit points. If any of these remain when the spell ends, they are lost.
@@ -1669,7 +1669,7 @@ Source:	Xanathar's Guide to Everything p. 168,
     <range>Touch</range>
     <components>V, S</components>
     <duration>8 hours</duration>
-    <classes>School: Transformation, Wizard</classes>
+    <classes>School: Transmutation, Wizard</classes>
     <text>You touch one Tiny, nonmagical object that isn't attached to another object or a surface and isn't being carried by another creature. The target animates and sprouts little arms and legs, becoming a creature under your control until the spell ends or the creature drops to 0 hit points. See the tiny servant for its statistics.
 	As a bonus action, you can mentally command the creature if it is within 120 feet of you. (If you control multiple creatures with this spell, you can command any or all of them at the same time, issuing the same command to each one.) You decide what action the creature will take and where it will move during its next turn, or you can issue a simple, general command, such as to fetch a key, stand watch, or stack some books. If you issue no commands, the servant does nothing other than defend itself against hostile creatures. Once given an order, the servant continues to follow that order until its task is complete.
 	When the creature drops to 0 hit points, it reverts to its original form, and any remaining damage carries over to that form.
@@ -1709,7 +1709,7 @@ Source:	Xanathar's Guide to Everything p. 169</text>
     <range>120 feet</range>
     <components>V, S, M (clay and water)</components>
     <duration>Until dispelled</duration>
-    <classes>School: Transformation, Druid, Wizard</classes>
+    <classes>School: Transmutation, Druid, Wizard</classes>
     <text>You choose an area of stone or mud that you can see that fits within a 40-foot cube and is within range, and choose one of the following effects.
 
 Transmute Rock to Mud: Nonmagical rock of any sort in the area becomes an equal volume of thick, flowing mud that remains for the spell's duration.
@@ -1934,7 +1934,7 @@ Source:	Xanathar's Guide to Everything p. 171</text>
     <range>Self</range>
     <components>V</components>
     <duration>Concentration, up to 1 minute</duration>
-    <classes>School: Transformation, Ranger</classes>
+    <classes>School: Transmutation, Ranger</classes>
     <text>You move like the wind. Until the spell ends, your movement doesn't provoke opportunity attacks.
 	Once before the spell ends, you can give yourself advantage on one weapon attack roll on your turn. That attack deals an extra 1d8 force damage on a hit. Whether you hit or miss, your walking speed increases by 30 feet until the end of that turn.
 

--- a/Sources_2024/Homebrew/WotC_2014_legacy/Adventures_homebrew_2014_legacy/Icewind_Dale_Rime_of_the_Frostmaiden/spells-idrotf.xml
+++ b/Sources_2024/Homebrew/WotC_2014_legacy/Adventures_homebrew_2014_legacy/Icewind_Dale_Rime_of_the_Frostmaiden/spells-idrotf.xml
@@ -23,7 +23,7 @@ Source:	Icewind Dale: Rime of the Frostmaiden p. 318</text>
   </spell-->
   <spell>
     <name>Create Magen</name>
-    <classes>School: Transformation, Wizard [2024]</classes>
+    <classes>School: Transmutation, Wizard [2024]</classes>
     <level>7</level>
     <school>T</school>
     <ritual>NO</ritual>

--- a/Sources_2024/Homebrew/WotC_2014_legacy/WizardsOfTheCoast_homebrew_2014_legacy/Spelljammer_Adventures_in_Space/spells-ais.xml
+++ b/Sources_2024/Homebrew/WotC_2014_legacy/WizardsOfTheCoast_homebrew_2014_legacy/Spelljammer_Adventures_in_Space/spells-ais.xml
@@ -23,7 +23,7 @@ Source:	Spelljammer: Adventures in Space - Astral Adventurer's Guide p. 22</text
     <range>Touch</range>
     <components>V, S, M (a crystal rod worth at least 5,000 gp, which the spell consumes)</components>
     <duration>Instantaneous</duration>
-    <classes>School: Transformation, Artificer, Wizard [2024]</classes>
+    <classes>School: Transmutation, Artificer, Wizard [2024]</classes>
     <text>Holding the rod used in the casting of the spell, you touch a Large or smaller chair that is unoccupied. The rod disappears, and the chair is transformed into a spelljamming helm.
 
 Source:	Spelljammer: Adventures in Space - Astral Adventurer's Guide p. 22</text>

--- a/Sources_2024/Homebrew/WotC_2014_legacy/WizardsOfTheCoast_homebrew_2014_legacy/Tashas_Cauldron_of_Everything/spells-phb+tce.xml
+++ b/Sources_2024/Homebrew/WotC_2014_legacy/WizardsOfTheCoast_homebrew_2014_legacy/Tashas_Cauldron_of_Everything/spells-phb+tce.xml
@@ -6,7 +6,7 @@
   </spell>
   <spell>
     <name>Aid [2024]</name>
-    <classes>Artificer, Cleric (Peace), Bard [2024], Ranger [2024]</classes>
+    <classes>Artificer, Cleric (Peace)</classes>
   </spell>
   <spell>
     <name>Alarm [2024]</name>
@@ -34,15 +34,15 @@
   </spell>
   <spell>
     <name>Aura of Life [2024]</name>
-    <classes>Cleric (Twilight), Druid (Wildfire), Cleric [2024]</classes>
+    <classes>Cleric (Twilight), Druid (Wildfire)</classes>
   </spell>
   <spell>
     <name>Aura of Purity [2024]</name>
-    <classes>Artificer (Battle Smith), Cleric (Peace), Paladin (Watchers), Cleric [2024]</classes>
+    <classes>Artificer (Battle Smith), Cleric (Peace), Paladin (Watchers)</classes>
   </spell>
   <spell>
     <name>Aura of Vitality [2024]</name>
-    <classes>Artificer (Battle Smith), Cleric (Twilight), Cleric [2024], Druid [2024]</classes>
+    <classes>Artificer (Battle Smith), Cleric (Twilight)</classes>
   </spell>
   <spell>
     <name>Banishing Smite [2024]</name>
@@ -62,7 +62,7 @@
   </spell>
   <spell>
     <name>Bigby's Hand [2024]</name>
-    <classes>Artificer, Warlock (Fathomless), Sorcerer [2024]</classes>
+    <classes>Artificer, Warlock (Fathomless)</classes>
   </spell>
   <spell>
     <name>Blight [2024]</name>
@@ -98,7 +98,7 @@
   </spell>
   <spell>
     <name>Command [2024]</name>
-    <classes>Cleric (Order), Bard [2024]</classes>
+    <classes>Cleric (Order)</classes>
   </spell>
   <spell>
     <name>Commune [2024]</name>
@@ -110,7 +110,7 @@
   </spell>
   <spell>
     <name>Cone of Cold [2024]</name>
-    <classes>Artificer (Artillerist), Warlock (Fathomless), Warlock (Genie), Druid [2024], Warlock (Genie Marid)</classes>
+    <classes>Artificer (Artillerist), Warlock (Fathomless), Warlock (Genie), Warlock (Genie Marid)</classes>
   </spell>
   <spell>
     <name>Confusion [2024]</name>
@@ -126,7 +126,7 @@
   </spell>
   <spell>
     <name>Continual Flame [2024]</name>
-    <classes>Artificer, Druid [2024]</classes>
+    <classes>Artificer</classes>
   </spell>
   <spell>
     <name>Control Water [2024]</name>
@@ -186,15 +186,15 @@
   </spell>
   <spell>
     <name>Elemental Weapon [2024]</name>
-    <classes>Artificer, Druid [2024], Ranger [2024]</classes>
+    <classes>Artificer</classes>
   </spell>
   <spell>
     <name>Enhance Ability [2024]</name>
-    <classes>Artificer, Paladin (Glory), Ranger [2024], Wizard [2024]</classes>
+    <classes>Artificer, Paladin (Glory)</classes>
   </spell>
   <spell>
     <name>Enlarge/Reduce [2024]</name>
-    <classes>Artificer, Bard [2024], Druid [2024]</classes>
+    <classes>Artificer</classes>
   </spell>
   <spell>
     <name>Expeditious Retreat [2024]</name>
@@ -222,7 +222,7 @@
   </spell>
   <spell>
     <name>Fire Shield [2024]</name>
-    <classes>Artificer (Battle Smith), Artificer (Armorer), Warlock (Genie), Warlock (Genie Efreeti), Druid (Wildfire), Druid [2024], Sorcerer [2024]</classes>
+    <classes>Artificer (Battle Smith), Artificer (Armorer), Warlock (Genie), Warlock (Genie Efreeti), Druid (Wildfire)</classes>
   </spell>
   <spell>
     <name>Fireball [2024]</name>
@@ -234,7 +234,7 @@
   </spell>
   <spell>
     <name>Flaming Sphere [2024]</name>
-    <classes>Artificer (Alchemist), Druid (Wildfire), Sorcerer [2024]</classes>
+    <classes>Artificer (Alchemist), Druid (Wildfire)</classes>
   </spell>
   <spell>
     <name>Fly [2024]</name>
@@ -254,7 +254,7 @@
   </spell>
   <spell>
     <name>Gentle Repose [2024]</name>
-    <classes>Druid (Spores), Paladin [2024]</classes>
+    <classes>Druid (Spores)</classes>
   </spell>
   <spell>
     <name>Glyph of Warding [2024]</name>
@@ -262,7 +262,7 @@
   </spell>
   <spell>
     <name>Grease [2024]</name>
-    <classes>Artificer, Sorcerer [2024]</classes>
+    <classes>Artificer</classes>
   </spell>
   <spell>
     <name>Greater Invisibility [2024]</name>
@@ -270,7 +270,7 @@
   </spell>
   <spell>
     <name>Greater Restoration [2024]</name>
-    <classes>Artificer, Cleric (Peace), Ranger [2024]</classes>
+    <classes>Artificer, Cleric (Peace)</classes>
   </spell>
   <spell>
     <name>Guidance [2024]</name>
@@ -282,7 +282,7 @@
   </spell>
   <spell>
     <name>Gust of Wind [2024]</name>
-    <classes>Warlock (Fathomless), Warlock (Genie), Warlock (Genie Djinni), Ranger [2024]</classes>
+    <classes>Warlock (Fathomless), Warlock (Genie), Warlock (Genie Djinni)</classes>
   </spell>
   <spell>
     <name>Haste [2024]</name>
@@ -378,7 +378,7 @@
   </spell>
   <spell>
     <name>Magic Weapon [2024]</name>
-    <classes>Artificer, Paladin (Glory), Ranger [2024], Sorcerer [2024]</classes>
+    <classes>Artificer, Paladin (Glory)</classes>
   </spell>
   <spell>
     <name>Mass Cure Wounds [2024]</name>
@@ -386,11 +386,11 @@
   </spell>
   <spell>
     <name>Mass Healing Word [2024]</name>
-    <classes>Cleric (Order), Artificer (Alchemist), Bard [2024]</classes>
+    <classes>Cleric (Order), Artificer (Alchemist)</classes>
   </spell>
   <spell>
     <name>Meld Into Stone [2024]</name>
-    <classes>Warlock (Genie), Warlock (Genie Dao), Ranger [2024]</classes>
+    <classes>Warlock (Genie), Warlock (Genie Dao)</classes>
   </spell>
   <spell>
     <name>Melf's Acid Arrow [2024]</name>
@@ -406,11 +406,11 @@
   </spell>
   <spell>
     <name>Mirror Image [2024]</name>
-    <classes>Artificer (Armorer), Bard [2024]</classes>
+    <classes>Artificer (Armorer)</classes>
   </spell>
   <spell>
     <name>Mislead [2024]</name>
-    <classes>Cleric (Twilight), Warlock [2024]</classes>
+    <classes>Cleric (Twilight)</classes>
   </spell>
   <spell>
     <name>Moonbeam [2024]</name>
@@ -442,7 +442,7 @@
   </spell>
   <spell>
     <name>Phantasmal Killer [2024]</name>
-    <classes>Warlock (Genie), Warlock (Genie Dao), Warlock (Genie Djinni), Warlock (Genie Efreeti), Warlock (Genie Marid), Bard [2024]</classes>
+    <classes>Warlock (Genie), Warlock (Genie Dao), Warlock (Genie Djinni), Warlock (Genie Efreeti), Warlock (Genie Marid)</classes>
   </spell>
   <spell>
     <name>Plant Growth [2024]</name>
@@ -462,7 +462,7 @@
   </spell>
   <spell>
     <name>Protection from Evil and Good [2024]</name>
-    <classes>, Druid [2024]</classes>
+    <classes></classes>
   </spell>
   <spell>
     <name>Protection from Poison [2024]</name>
@@ -478,7 +478,7 @@
   </spell>
   <spell>
     <name>Rary's Telepathic Bond</name>
-    <classes>Cleric (Peace), Bard [2024]</classes>
+    <classes>Cleric (Peace)</classes>
   </spell>
   <spell>
     <name>Ray of Frost [2024]</name>
@@ -494,7 +494,7 @@
   </spell>
   <spell>
     <name>Revivify [2024]</name>
-    <classes>Artificer, Druid (Wildfire), Druid [2024], Ranger [2024]</classes>
+    <classes>Artificer, Druid (Wildfire)</classes>
   </spell>
   <spell>
     <name>Rope Trick [2024]</name>
@@ -546,7 +546,7 @@
   </spell>
   <spell>
     <name>Slow [2024]</name>
-    <classes>Cleric (Order), Bard [2024]</classes>
+    <classes>Cleric (Order)</classes>
   </spell>
   <spell>
     <name>Spare the Dying [2024]</name>
@@ -598,7 +598,7 @@
   </spell>
   <spell>
     <name>Warding Bond [2024]</name>
-    <classes>Artificer (Battle Smith), Cleric (Peace), Paladin [2024]</classes>
+    <classes>Artificer (Battle Smith), Cleric (Peace)</classes>
   </spell>
   <spell>
     <name>Water Breathing [2024]</name>

--- a/Sources_2024/Homebrew/WotC_2014_legacy/WizardsOfTheCoast_homebrew_2014_legacy/Tashas_Cauldron_of_Everything/spells-tce.xml
+++ b/Sources_2024/Homebrew/WotC_2014_legacy/WizardsOfTheCoast_homebrew_2014_legacy/Tashas_Cauldron_of_Everything/spells-tce.xml
@@ -389,7 +389,7 @@ Source:	Tasha's Cauldron of Everything p. 115</text>
   </spell>
   <spell>
     <name>Tasha's Otherworldly Guise</name>
-    <classes>School: Transformation, Sorcerer [2024], Warlock [2024], Wizard [2024]</classes>
+    <classes>School: Transmutation, Sorcerer [2024], Warlock [2024], Wizard [2024]</classes>
     <level>6</level>
     <school>T</school>
     <ritual>NO</ritual>

--- a/Sources_2024/Homebrew/WotC_2014_legacy/WizardsOfTheCoast_homebrew_2014_legacy/Xanathars_Guide_to_Everything/spells-xge.xml
+++ b/Sources_2024/Homebrew/WotC_2014_legacy/WizardsOfTheCoast_homebrew_2014_legacy/Xanathars_Guide_to_Everything/spells-xge.xml
@@ -809,7 +809,7 @@ Source:	Xanathar's Guide to Everything p. 157</text>
     <roll>2d8</roll>
     <roll>4d8</roll>
   </spell>
-  <spell>
+  <!-- <spell>
     <name>Ice Knife</name>
     <classes>School: Conjuration, Druid [2024], Sorcerer [2024], Wizard [2024]</classes>
     <level>1</level>
@@ -835,7 +835,7 @@ Source:	Xanathar's Guide to Everything p. 157,
     <roll>8d6</roll>
     <roll>9d6</roll>
     <roll>10d6</roll>
-  </spell>
+  </spell> -->
   <spell>
     <name>Illusory Dragon</name>
     <classes>School: Illusion, Wizard [2024]</classes>
@@ -2062,7 +2062,7 @@ Source:	Xanathar's Guide to Everything p. 171,
     <roll>10d6</roll>
     <roll>3d6</roll>
   </spell>
-  <spell>
+  <!-- <spell>
     <name>Word of Radiance</name>
     <classes>School: Evocation, Cleric [2024]</classes>
     <level>0</level>
@@ -2081,7 +2081,7 @@ Source:	Xanathar's Guide to Everything p. 171</text>
     <roll>2d6</roll>
     <roll>3d6</roll>
     <roll>4d6</roll>
-  </spell>
+  </spell> -->
   <spell>
     <name>Wrath of Nature</name>
     <classes>School: Evocation, Druid [2024], Ranger [2024]</classes>

--- a/Sources_2024/Homebrew/WotC_2014_legacy/WizardsOfTheCoast_homebrew_2014_legacy/Xanathars_Guide_to_Everything/spells-xge.xml
+++ b/Sources_2024/Homebrew/WotC_2014_legacy/WizardsOfTheCoast_homebrew_2014_legacy/Xanathars_Guide_to_Everything/spells-xge.xml
@@ -86,7 +86,7 @@ Source:	Xanathar's Guide to Everything p. 150,
   </spell>
   <spell>
     <name>Bones of the Earth</name>
-    <classes>School: Transformation, Druid [2024]</classes>
+    <classes>School: Transmutation, Druid [2024]</classes>
     <level>6</level>
     <school>T</school>
     <ritual>NO</ritual>
@@ -113,7 +113,7 @@ Source:	Xanathar's Guide to Everything p. 150,
   </spell>
   <spell>
     <name>Catapult</name>
-    <classes>School: Transformation, Sorcerer [2024], Wizard [2024]</classes>
+    <classes>School: Transmutation, Sorcerer [2024], Wizard [2024]</classes>
     <level>1</level>
     <school>T</school>
     <ritual>NO</ritual>
@@ -265,7 +265,7 @@ Source:	Xanathar's Guide to Everything p. 151</text>
   </spell> -->
   <spell>
     <name>Control Flames</name>
-    <classes>School: Transformation, Druid [2024], Sorcerer [2024], Wizard [2024]</classes>
+    <classes>School: Transmutation, Druid [2024], Sorcerer [2024], Wizard [2024]</classes>
     <level>0</level>
     <school>T</school>
     <ritual>NO</ritual>
@@ -287,7 +287,7 @@ Source:	Xanathar's Guide to Everything p. 152,
   </spell>
   <spell>
     <name>Control Winds</name>
-    <classes>School: Transformation, Druid [2024], Sorcerer [2024], Wizard [2024]</classes>
+    <classes>School: Transmutation, Druid [2024], Sorcerer [2024], Wizard [2024]</classes>
     <level>5</level>
     <school>T</school>
     <ritual>NO</ritual>
@@ -339,7 +339,7 @@ Source:	Xanathar's Guide to Everything p. 152,
   </spell>
   <spell>
     <name>Create Homunculus</name>
-    <classes>School: Transformation, Wizard [2024]</classes>
+    <classes>School: Transmutation, Wizard [2024]</classes>
     <level>6</level>
     <school>T</school>
     <ritual>NO</ritual>
@@ -416,7 +416,7 @@ Source:	Xanathar's Guide to Everything p. 153</text>
   </spell>
   <!-- <spell>
     <name>Dragon's Breath</name>
-    <classes>School: Transformation, Sorcerer [2024], Wizard [2024]</classes>
+    <classes>School: Transmutation, Sorcerer [2024], Wizard [2024]</classes>
     <level>2</level>
     <school>T</school>
     <ritual>NO</ritual>
@@ -536,7 +536,7 @@ Source:	Xanathar's Guide to Everything p. 155,
   </spell>
   <spell>
     <name>Earthbind</name>
-    <classes>School: Transformation, Druid [2024], Sorcerer [2024], Warlock [2024], Wizard [2024]</classes>
+    <classes>School: Transmutation, Druid [2024], Sorcerer [2024], Warlock [2024], Wizard [2024]</classes>
     <level>2</level>
     <school>T</school>
     <ritual>NO</ritual>
@@ -551,7 +551,7 @@ Source:	Xanathar's Guide to Everything p. 154,
   </spell>
   <spell>
     <name>Elemental Bane</name>
-    <classes>School: Transformation, Druid [2024], Warlock [2024], Wizard [2024]</classes>
+    <classes>School: Transmutation, Druid [2024], Warlock [2024], Wizard [2024]</classes>
     <level>4</level>
     <school>T</school>
     <ritual>NO</ritual>
@@ -610,7 +610,7 @@ Source:	Xanathar's Guide to Everything p. 155</text>
   </spell>
   <spell>
     <name>Erupting Earth</name>
-    <classes>School: Transformation, Druid [2024], Sorcerer [2024], Wizard [2024]</classes>
+    <classes>School: Transmutation, Druid [2024], Sorcerer [2024], Wizard [2024]</classes>
     <level>3</level>
     <school>T</school>
     <ritual>NO</ritual>
@@ -670,7 +670,7 @@ Source:	Xanathar's Guide to Everything p. 156</text>
   </spell>
   <spell>
     <name>Flame Arrows</name>
-    <classes>School: Transformation, Druid [2024], Ranger [2024], Sorcerer [2024], Wizard [2024]</classes>
+    <classes>School: Transmutation, Druid [2024], Ranger [2024], Sorcerer [2024], Wizard [2024]</classes>
     <level>3</level>
     <school>T</school>
     <ritual>NO</ritual>
@@ -709,7 +709,7 @@ Source:	Xanathar's Guide to Everything p. 156,
   </spell>
   <spell>
     <name>Guardian of Nature</name>
-    <classes>School: Transformation, Druid [2024], Ranger [2024]</classes>
+    <classes>School: Transmutation, Druid [2024], Ranger [2024]</classes>
     <level>4</level>
     <school>T</school>
     <ritual>NO</ritual>
@@ -740,7 +740,7 @@ Source:	Xanathar's Guide to Everything p. 157</text>
   </spell>
   <spell>
     <name>Gust</name>
-    <classes>School: Transformation, Druid [2024], Sorcerer [2024], Wizard [2024]</classes>
+    <classes>School: Transmutation, Druid [2024], Sorcerer [2024], Wizard [2024]</classes>
     <level>0</level>
     <school>T</school>
     <ritual>NO</ritual>
@@ -924,7 +924,7 @@ Source:	Xanathar's Guide to Everything p. 158</text>
   </spell>
   <spell>
     <name>Investiture of Flame</name>
-    <classes>School: Transformation, Druid [2024], Sorcerer [2024], Warlock [2024], Wizard [2024]</classes>
+    <classes>School: Transmutation, Druid [2024], Sorcerer [2024], Warlock [2024], Wizard [2024]</classes>
     <level>6</level>
     <school>T</school>
     <ritual>NO</ritual>
@@ -945,7 +945,7 @@ Source:	Xanathar's Guide to Everything p. 159,
   </spell>
   <spell>
     <name>Investiture of Ice</name>
-    <classes>School: Transformation, Druid [2024], Sorcerer [2024], Warlock [2024], Wizard [2024]</classes>
+    <classes>School: Transmutation, Druid [2024], Sorcerer [2024], Warlock [2024], Wizard [2024]</classes>
     <level>6</level>
     <school>T</school>
     <ritual>NO</ritual>
@@ -966,7 +966,7 @@ Source:	Xanathar's Guide to Everything p. 159,
   </spell>
   <spell>
     <name>Investiture of Stone</name>
-    <classes>School: Transformation, Druid [2024], Sorcerer [2024], Warlock [2024], Wizard [2024]</classes>
+    <classes>School: Transmutation, Druid [2024], Sorcerer [2024], Warlock [2024], Wizard [2024]</classes>
     <level>6</level>
     <school>T</school>
     <ritual>NO</ritual>
@@ -995,7 +995,7 @@ Source:	Xanathar's Guide to Everything p. 159,
   </spell>
   <spell>
     <name>Investiture of Wind</name>
-    <classes>School: Transformation, Druid [2024], Sorcerer [2024], Warlock [2024], Wizard [2024]</classes>
+    <classes>School: Transmutation, Druid [2024], Sorcerer [2024], Warlock [2024], Wizard [2024]</classes>
     <level>6</level>
     <school>T</school>
     <ritual>NO</ritual>
@@ -1085,7 +1085,7 @@ Source:	Xanathar's Guide to Everything p. 160,
   </spell>
   <spell>
     <name>Magic Stone</name>
-    <classes>School: Transformation, Druid [2024], Warlock [2024]</classes>
+    <classes>School: Transmutation, Druid [2024], Warlock [2024]</classes>
     <level>0</level>
     <school>T</school>
     <ritual>NO</ritual>
@@ -1103,7 +1103,7 @@ Source:	Xanathar's Guide to Everything p. 160,
   </spell>
   <spell>
     <name>Mass Polymorph</name>
-    <classes>School: Transformation, Bard [2024], Sorcerer [2024], Wizard [2024]</classes>
+    <classes>School: Transmutation, Bard [2024], Sorcerer [2024], Wizard [2024]</classes>
     <level>9</level>
     <school>T</school>
     <ritual>NO</ritual>
@@ -1125,7 +1125,7 @@ Source:	Xanathar's Guide to Everything p. 160</text>
   </spell>
   <spell>
     <name>Maximilian's Earthen Grasp</name>
-    <classes>School: Transformation, Sorcerer [2024], Wizard [2024]</classes>
+    <classes>School: Transmutation, Sorcerer [2024], Wizard [2024]</classes>
     <level>2</level>
     <school>T</school>
     <ritual>NO</ritual>
@@ -1241,7 +1241,7 @@ Source:	Xanathar's Guide to Everything p. 162</text>
   </spell> -->
   <spell>
     <name>Mold Earth</name>
-    <classes>School: Transformation, Druid [2024], Sorcerer [2024], Wizard [2024]</classes>
+    <classes>School: Transmutation, Druid [2024], Sorcerer [2024], Wizard [2024]</classes>
     <level>0</level>
     <school>T</school>
     <ritual>NO</ritual>
@@ -1297,7 +1297,7 @@ Source:	Xanathar's Guide to Everything p. 163</text>
   </spell>
   <spell>
     <name>Primal Savagery</name>
-    <classes>School: Transformation, Druid [2024]</classes>
+    <classes>School: Transmutation, Druid [2024]</classes>
     <level>0</level>
     <school>T</school>
     <ritual>NO</ritual>
@@ -1353,7 +1353,7 @@ Source:	Xanathar's Guide to Everything p. 163</text>
   </spell>
   <spell>
     <name>Pyrotechnics</name>
-    <classes>School: Transformation, Bard [2024], Sorcerer [2024], Wizard [2024]</classes>
+    <classes>School: Transmutation, Bard [2024], Sorcerer [2024], Wizard [2024]</classes>
     <level>2</level>
     <school>T</school>
     <ritual>NO</ritual>
@@ -1431,7 +1431,7 @@ Source:	Xanathar's Guide to Everything p. 164</text>
   </spell>
   <spell>
     <name>Shape Water</name>
-    <classes>School: Transformation, Druid [2024], Sorcerer [2024], Wizard [2024]</classes>
+    <classes>School: Transmutation, Druid [2024], Sorcerer [2024], Wizard [2024]</classes>
     <level>0</level>
     <school>T</school>
     <ritual>NO</ritual>
@@ -1471,7 +1471,7 @@ Source:	Xanathar's Guide to Everything p. 164</text>
   </spell>
   <spell>
     <name>Skill Empowerment</name>
-    <classes>School: Transformation, Bard [2024], Sorcerer [2024], Wizard [2024]</classes>
+    <classes>School: Transmutation, Bard [2024], Sorcerer [2024], Wizard [2024]</classes>
     <level>5</level>
     <school>T</school>
     <ritual>NO</ritual>
@@ -1487,7 +1487,7 @@ Source:	Xanathar's Guide to Everything p. 165</text>
   </spell>
   <spell>
     <name>Skywrite</name>
-    <classes>School: Transformation, Bard [2024], Druid [2024], Wizard [2024]</classes>
+    <classes>School: Transmutation, Bard [2024], Druid [2024], Wizard [2024]</classes>
     <level>2</level>
     <school>T</school>
     <ritual>YES</ritual>
@@ -1723,7 +1723,7 @@ Source:	Xanathar's Guide to Everything p. 167</text>
   </spell>
   <spell>
     <name>Tenser's Transformation</name>
-    <classes>School: Transformation, Wizard [2024]</classes>
+    <classes>School: Transmutation, Wizard [2024]</classes>
     <level>6</level>
     <school>T</school>
     <ritual>NO</ritual>
@@ -1814,7 +1814,7 @@ Source:	Xanathar's Guide to Everything p. 168,
   </spell>
   <spell>
     <name>Tiny Servant</name>
-    <classes>School: Transformation, Wizard [2024]</classes>
+    <classes>School: Transmutation, Wizard [2024]</classes>
     <level>3</level>
     <school>T</school>
     <ritual>NO</ritual>
@@ -1858,7 +1858,7 @@ Source:	Xanathar's Guide to Everything p. 169</text>
   </spell> -->
   <spell>
     <name>Transmute Rock</name>
-    <classes>School: Transformation, Druid [2024], Wizard [2024]</classes>
+    <classes>School: Transmutation, Druid [2024], Wizard [2024]</classes>
     <level>5</level>
     <school>T</school>
     <ritual>NO</ritual>
@@ -2112,7 +2112,7 @@ Source:	Xanathar's Guide to Everything p. 171</text>
   </spell>
   <spell>
     <name>Zephyr Strike</name>
-    <classes>School: Transformation, Ranger [2024]</classes>
+    <classes>School: Transmutation, Ranger [2024]</classes>
     <level>1</level>
     <school>T</school>
     <ritual>NO</ritual>

--- a/Sources_2024/WizardsOfTheCoast/01_Players_Handbook_2024/class-ranger-phb24.xml
+++ b/Sources_2024/WizardsOfTheCoast/01_Players_Handbook_2024/class-ranger-phb24.xml
@@ -70,9 +70,9 @@ You can use a Druidic Focus as a Spellcasting Focus for your Ranger spells.
 Level | Spells Prepared
 1 | 2
 2 | 3
-2 | 4
-3 | 5
-4 | 6
+3 | 4
+4 | 5
+5 | 6
 7 | 7
 9 | 9
 11 | 10

--- a/Sources_2024/WizardsOfTheCoast/01_Players_Handbook_2024/spells-phb24.xml
+++ b/Sources_2024/WizardsOfTheCoast/01_Players_Handbook_2024/spells-phb24.xml
@@ -8,7 +8,7 @@
     <range>60 feet</range>
     <components>V, S</components>
     <duration>Instantaneous</duration>
-    <classes>Sorcerer [2024], Wizard [2024], Druid [2024] (Tropical Land)</classes>
+    <classes>School: Evocation, Sorcerer [2024], Wizard [2024], Druid [2024] (Tropical Land)</classes>
     <text>You create an acidic bubble at a point within range, where it explodes in a 5-foot-radius Sphere. Each creature in that Sphere must succeed on a Dexterity saving throw or take 1d6 Acid damage.
 
 Cantrip Upgrade: The damage increases by 1d6 when you reach levels 5 (2d6), 11 (3d6), and 17 (4d6).
@@ -27,7 +27,7 @@ Source:	Player's Handbook 2024 p. 239</text>
     <range>30 feet</range>
     <components>V, S, M (a strip of white cloth)</components>
     <duration>8 hour</duration>
-    <classes>Bard [2024], Cleric [2024], Druid [2024], Ranger [2024], Paladin [2024], Cleric [2024] (Life), Paladin [2024] (Devotion), Sorcerer [2024] (Clockwork), Warlock [2024] (Celestial)</classes>
+    <classes>School: Abjuration, Bard [2024], Cleric [2024], Druid [2024], Ranger [2024], Paladin [2024], Cleric [2024] (Life), Paladin [2024] (Devotion), Sorcerer [2024] (Clockwork), Warlock [2024] (Celestial)</classes>
     <text>Choose up to three creatures within range. Each target's Hit Points maximum and current Hit Points increase by 5 for the duration.
 
 Using a Higher-Level Spell Slot:
@@ -44,7 +44,7 @@ Source:	Player's Handbook 2024 p. 239</text>
     <range>30 feet</range>
     <components>V, S, M (a bell and silver wire)</components>
     <duration>8 hour</duration>
-    <classes>Ranger [2024], Wizard [2024], Sorcerer [2024] (Clockwork)</classes>
+    <classes>School: Abjuration, Ranger [2024], Wizard [2024], Sorcerer [2024] (Clockwork)</classes>
     <text>You set an alarm against intrusion. Choose a door, a window, or an area within range that is no larger than a 20-foot Cube. Until the spell ends, an alarm alerts you whenever a creature touches or enters the warded area. When you cast the spell, you can designate creatures that won't set off the alarm. You also choose whether the alarm is audible or mental:
 
 Audible Alarm:
@@ -63,7 +63,7 @@ Source:	Player's Handbook 2024 p. 239</text>
     <range>Self</range>
     <components>V, S</components>
     <duration>Concentration, up to 1 hour</duration>
-    <classes>Sorcerer [2024], Wizard [2024], Sorcerer [2024] (Draconic)</classes>
+    <classes>School: Transmutation, Sorcerer [2024], Wizard [2024], Sorcerer [2024] (Draconic)</classes>
     <text>You alter your physical form. Choose one of the following options. Its effects last for the duration, during which you can take a Magic action to replace the option you chose with a different one.
 
 Aquatic Adaptation:
@@ -86,7 +86,7 @@ Source:	Player's Handbook 2024 p. 239</text>
     <range>30 feet</range>
     <components>V, S, M (a morsel of food)</components>
     <duration>24 hour</duration>
-    <classes>Bard [2024], Druid [2024], Ranger [2024]</classes>
+    <classes>School: Enchantment, Bard [2024], Druid [2024], Ranger [2024]</classes>
     <text>Target a Beast that you can see within range. The target must succeed on a Wisdom saving throw or have the Charmed condition for the duration. If you or one of your allies deals damage to the target, the spells ends.
 
 Using a Higher-Level Spell Slot:
@@ -103,7 +103,7 @@ Source:	Player's Handbook 2024 p. 239</text>
     <range>30 feet</range>
     <components>V, S, M (a morsel of food)</components>
     <duration>24 hour</duration>
-    <classes>Bard [2024], Druid [2024], Ranger [2024]</classes>
+    <classes>School: Enchantment, Bard [2024], Druid [2024], Ranger [2024]</classes>
     <text>A Tiny Beast of your choice that you can see within range must succeed on a Charisma saving throw, or it attempts to deliver a message for you (if the target's Challenge Rating isn't 0, it automatically succeeds). You specify a location you have visited and a recipient who matches a general description, such as "a person dressed in the uniform of the town guard" or "a red-haired dwarf wearing a pointed hat." You also communicate a message of up to twenty-five words. The Beast travels for the duration toward the specified location, covering about 25 miles per 24 hours or 50 miles if the Beast can fly.
 
 When the Beast arrives, it delivers your message to the creature that you described, mimicking your communication. If the Beast doesn't reach its destination before the spell ends, the message is lost, and the Beast returns to where you cast the spell.
@@ -121,7 +121,7 @@ Source:	Player's Handbook 2024 p. 240</text>
     <range>30 feet</range>
     <components>V, S</components>
     <duration>Concentration, up to 24 hour</duration>
-    <classes>Druid [2024]</classes>
+    <classes>School: Transmutation, Druid [2024]</classes>
     <text>Choose any number of willing creatures that you can see within range. Each target shape-shifts into a Large or smaller Beast of your choice that has a Challenge Rating of 4 or lower. You can choose a different form for each target. On later turns, you can take a Magic action to transform the targets again.
 
 A target's game statistics are replaced by the chosen Beast's statistics, but the target retains its creature type; Hit Points; Hit Point Dice; alignment; ability to communicate; and Intelligence, Wisdom, and Charisma scores. The target's actions are limited by the Beast form's anatomy, and it can't cast spells. The target's equipment melds into the new form, and the target can't use any of that equipment while in that form.
@@ -138,7 +138,7 @@ Source:	Player's Handbook 2024 p. 240</text>
     <range>10 feet</range>
     <components>V, S, M (a drop of blood, a piece of flesh, and a pinch of bone dust)</components>
     <duration>Instantaneous</duration>
-    <classes>Cleric [2024], Wizard [2024]</classes>
+    <classes>School: Necromancy, Cleric [2024], Wizard [2024]</classes>
     <text>Choose a pile of bones or a corpse of a Medium or Small Humanoid within range. The target becomes an Undead creature: a Skeleton if you chose bones or a Zombie if you chose a corpse.
 
 On each of your turns, you can take a Bonus Action to mentally command any creature you made with this spell if the creature is within 60 feet of you (if you control multiple creatures, you can command any of them at the same time, issuing the same command to each one). You decide what action the creature will take and where it will move on its next turn, or you can issue a general command, such as to guard a chamber or corridor. If you issue no commands, the creature takes the Dodge action and moves only to avoid harm. Once given an order, the creature continues to follow it until its task is complete.
@@ -158,7 +158,7 @@ Source:	Player's Handbook 2024 p. 240</text>
     <range>120 feet</range>
     <components>V, S</components>
     <duration>Concentration, up to 1 minute</duration>
-    <classes>Bard [2024], Sorcerer [2024], Wizard [2024]</classes>
+    <classes>School: Transmutation, Bard [2024], Sorcerer [2024], Wizard [2024]</classes>
     <text>Objects animate at your command. Choose a number of nonmagical objects within range that aren't being worn or carried, aren't fixed to a surface, and aren't Gargantuan. The maximum number of objects is equal to your spellcasting ability modifier; for this number, a Medium or smaller target counts as one object, a Large target counts as two, and a Huge target counts as three.
 
 Each target animates, sprouts legs, and becomes a Construct that uses the Animated Object stat block; this creature is under your control until the spell ends or until it is reduced to 0 Hit Points. Each creature you make with this spell is an ally to you and your allies. In combat, it shares your Initiative count and takes its turn immediately after yours.
@@ -181,7 +181,7 @@ Source:	Player's Handbook 2024 p. 240</text>
     <range>Self</range>
     <components>V, S</components>
     <duration>Concentration, up to 1 hour</duration>
-    <classes>Druid [2024]</classes>
+    <classes>School: Abjuration, Druid [2024]</classes>
     <text>An aura extends from you in a 10-foot Emanation for the duration. The aura prevents creatures other than Constructs and Undead from passing or reaching through it. An affected creature can cast spells or make attacks with Ranged or Reach weapons through the barrier.
 
 If you move so that an affected creature is forced to pass through the barrier, the spell ends.
@@ -196,7 +196,7 @@ Source:	Player's Handbook 2024 p. 241</text>
     <range>Self</range>
     <components>V, S, M (iron filings)</components>
     <duration>Concentration, up to 1 hour</duration>
-    <classes>Cleric [2024], Wizard [2024]</classes>
+    <classes>School: Abjuration, Cleric [2024], Wizard [2024]</classes>
     <text>An aura of antimagic surrounds you in 10-foot Emanation. No one can cast spells, take Magic actions, or create other magical effects inside the aura, and those things can't target or otherwise affect anything inside it. Magical properties of magic items don't work inside the aura or on anything inside it.
 
 Areas of effect created by spells or other magic can't extend into the aura, and no one can teleport into or out of it or use planar travel there. Portals close temporarily while in the aura.
@@ -215,7 +215,7 @@ Source:	Player's Handbook 2024 p. 241</text>
     <range>60 feet</range>
     <components>V, S, M (a mix of vinegar and honey)</components>
     <duration>10 day</duration>
-    <classes>Bard [2024], Druid [2024], Wizard [2024]</classes>
+    <classes>School: Enchantment, Bard [2024], Druid [2024], Wizard [2024]</classes>
     <text>As you cast the spell, choose whether it creates antipathy or sympathy, and target one creature or object that is Huge or smaller. Then specify a kind of creature, such as red dragons, goblins, or vampires. A creature of the chosen kind makes a Wisdom saving throw when it comes within 120 feet of the target. Your choice of antipathy or sympathy determines what happens to a creature when it fails that save:
 
 Antipathy:
@@ -237,7 +237,7 @@ Source:	Player's Handbook 2024 p. 242</text>
     <range>30 feet</range>
     <components>V, S, M (a bit of bat fur)</components>
     <duration>Concentration, up to 1 hour</duration>
-    <classes>Wizard [2024], Cleric [2024] (Light), Sorcerer [2024] (Draconic)</classes>
+    <classes>School: Divination, Wizard [2024], Cleric [2024] (Light), Sorcerer [2024] (Draconic)</classes>
     <text>You create an Invisible, invulnerable eye within range that hovers for the duration. You mentally receive visual information from the eye, which can see in every direction. It also has Darkvision with a range of 30 feet.
 
 As a Bonus Action, you can move the eye up to 30 feet in any direction. A solid barrier blocks the eye's movement, but the eye can pass through an opening as small as 1 inch in diameter.
@@ -252,7 +252,7 @@ Source:	Player's Handbook 2024 p. 242</text>
     <range>500 feet</range>
     <components>V, S</components>
     <duration>Concentration, up to 10 minute</duration>
-    <classes>Sorcerer [2024], Warlock [2024], Wizard [2024]</classes>
+    <classes>School: Conjuration, Sorcerer [2024], Warlock [2024], Wizard [2024]</classes>
     <text>You create linked teleportation portals. Choose two Large, unoccupied spaces on the ground that you can see, one space within range and the other one within 10 feet of you. A circular portal opens in each of those spaces and remains for the duration.
 
 The portals are two-dimensional glowing rings filled with mist that blocks sight. They hover inches from the ground and are perpendicular to it.
@@ -269,7 +269,7 @@ Source:	Player's Handbook 2024 p. 242</text>
     <range>Touch</range>
     <components>V, S, M (gold dust worth 25+ GP, which the spell consumes)</components>
     <duration/>
-    <classes>Wizard [2024]</classes>
+    <classes>School: Abjuration, Wizard [2024]</classes>
     <text>You touch a closed door, window, gate, container, or hatch and magically lock it for the duration. This lock can't be unlocked by any nonmagical means. You and any creatures you designate when you cast the spell can open and close the object despite the lock. You can also set a password that, when spoken within 5 feet of the object, unlocks it for 1 minute.
 
 Source:	Player's Handbook 2024 p. 242</text>
@@ -282,7 +282,7 @@ Source:	Player's Handbook 2024 p. 242</text>
     <range>Self</range>
     <components>V, S</components>
     <duration>Instantaneous</duration>
-    <classes>Sorcerer [2024], Wizard [2024]</classes>
+    <classes>School: Abjuration, Sorcerer [2024], Wizard [2024]</classes>
     <text>You tap into your life force to heal yourself. Roll one or two of your unexpended Hit Point Dice, and regain a number of Hit Points equal to the roll's total plus your spellcasting ability modifier. Those dice are then expended.
 
 Using a Higher-Level Spell Slot:
@@ -298,7 +298,7 @@ Source:	Player's Handbook 2024 p. 242</text>
     <range>Self</range>
     <components>V, S, M (a shard of blue glass)</components>
     <duration>1 hour</duration>
-    <classes>Warlock [2024]</classes>
+    <classes>School: Abjuration, Warlock [2024]</classes>
     <text>Protective magical frost surrounds you. You gain 5 Temporary Hit Points. If a creature hits you with a melee attack roll before the spell ends, the creature takes 5 Cold damage. The spell ends early if you have no Temporary Hit Points.
 
 Using a Higher-Level Spell Slot:
@@ -314,7 +314,7 @@ Source:	Player's Handbook 2024 p. 243</text>
     <range>Self</range>
     <components>V, S</components>
     <duration>Instantaneous</duration>
-    <classes>Warlock [2024], Sorcerer [2024] (Aberrant)</classes>
+    <classes>School: Conjuration, Warlock [2024], Sorcerer [2024] (Aberrant)</classes>
     <text>Invoking Hadar, you cause tendrils to erupt from yourself. Each creature in a 10-foot Emanation originating from you makes a Strength saving throw. On a failed save, a target takes 2d6 Necrotic damage and can't take Reactions until the start of its next turn. On a successful save, a target takes half as much damage only.
 
 Using a Higher-Level Spell Slot:
@@ -339,7 +339,7 @@ Source:	Player's Handbook 2024 p. 243</text>
     <range>10 feet</range>
     <components>V, S, M (for each of the spell's targets, one jacinth worth 1,000+ GP and one silver bar worth 100+ GP, all of which the spell consumes)</components>
     <duration/>
-    <classes>Cleric [2024], Warlock [2024], Wizard [2024]</classes>
+    <classes>School: Necromancy, Cleric [2024], Warlock [2024], Wizard [2024]</classes>
     <text>You and up to eight willing creatures within range project your astral bodies into the Astral Plane (the spell ends instantly if you are already on that plane). Each target's body is left behind in a state of suspended animation; it has the Unconscious condition, doesn't need food or air, and doesn't age.
 
 A target's astral form resembles its body in almost every way, replicating its game statistics and possessions. The principal difference is the addition of a silvery cord that trails from between the shoulder blades of the astral form. The cord fades from view after 1 foot. If the cord is cut—which happens only when an effect states that it does so—the target's body and astral form both die.
@@ -361,7 +361,7 @@ Source:	Player's Handbook 2024 p. 243</text>
     <range>Self</range>
     <components>V, S, M (specially marked sticks, bones, cards, or other divinatory tokens worth 25+ GP)</components>
     <duration>Instantaneous</duration>
-    <classes>Cleric [2024], Druid [2024], Wizard [2024]</classes>
+    <classes>School: Divination, Cleric [2024], Druid [2024], Wizard [2024]</classes>
     <text>You receive an omen from an otherworldly entity about the results of a course of action that you plan to take within the next 30 minutes. The DM chooses the omen from the Omens table.
 
 Omens:
@@ -381,7 +381,7 @@ Source:	Player's Handbook 2024 p. 244</text>
     <range>Self</range>
     <components>V</components>
     <duration>Concentration, up to 10 minute</duration>
-    <classes>Cleric [2024], Paladin [2024], Cleric [2024] (Life)</classes>
+    <classes>School: Abjuration, Cleric [2024], Paladin [2024], Cleric [2024] (Life)</classes>
     <text>An aura radiates from you in a 30-foot Emanation for the duration. While in the aura, you and your allies have Resistance to Necrotic damage, and your Hit Point maximums can't be reduced. If an ally with 0 Hit Points starts its turn in the aura, that ally regains 1 Hit Point.
 
 Source:	Player's Handbook 2024 p. 244</text>
@@ -394,7 +394,7 @@ Source:	Player's Handbook 2024 p. 244</text>
     <range>Self</range>
     <components>V</components>
     <duration>Concentration, up to 10 minute</duration>
-    <classes>Cleric [2024], Paladin [2024]</classes>
+    <classes>School: Abjuration, Cleric [2024], Paladin [2024]</classes>
     <text>An aura radiates from you in a 30-foot Emanation for the duration. While in the aura, you and your allies have Resistance to Poison damage and Advantage on saving throws to avoid or end effects that include the Blinded, Charmed, Deafened, Frightened, Paralyzed, Poisoned, or Stunned condition.
 
 Source:	Player's Handbook 2024 p. 244</text>
@@ -407,7 +407,7 @@ Source:	Player's Handbook 2024 p. 244</text>
     <range>Self</range>
     <components>V</components>
     <duration>Concentration, up to 1 minute</duration>
-    <classes>Cleric [2024], Druid [2024], Paladin [2024]</classes>
+    <classes>School: Abjuration, Cleric [2024], Druid [2024], Paladin [2024]</classes>
     <text>An aura radiates from you in a 30-foot Emanation for the duration. When you create the aura and at the start of each of your turns while it persists, you can restore 2d6 Hit Points to one creature in it.
 
 Source:	Player's Handbook 2024 p. 244</text>
@@ -421,7 +421,7 @@ Source:	Player's Handbook 2024 p. 244</text>
     <range>Touch</range>
     <components>V, S, M (an agate worth 1,000+ GP, which the spell consumes)</components>
     <duration>Instantaneous</duration>
-    <classes>Bard [2024], Druid [2024]</classes>
+    <classes>School: Transmutation, Bard [2024], Druid [2024]</classes>
     <text>You spend the casting time tracing magical pathways within a precious gemstone, and then touch the target. The target must be either a Beast or Plant creature with an Intelligence of 3 or less or a natural plant that isn't a creature. The target gains an Intelligence of 10 and the ability to speak one language you know. If the target is a natural plant, it becomes a Plant creature and gains the ability to move its limbs, roots, vines, creepers, and so forth, and it gains senses similar to a human's. The DM chooses statistics appropriate for the awakened Plant, such as the statistics for the Awakened Shrub or Awakened Tree in the the XMM.
 
 The awakened target has the Charmed condition for 30 days or until you or your allies deal damage to it. When that condition ends, the awakened creature chooses its attitude toward you.
@@ -436,7 +436,7 @@ Source:	Player's Handbook 2024 p. 245</text>
     <range>30 feet</range>
     <components>V, S, M (a drop of blood)</components>
     <duration>Concentration, up to 1 minute</duration>
-    <classes>Bard [2024], Cleric [2024], Warlock [2024], Paladin [2024] (Vengeance)</classes>
+    <classes>School: Enchantment, Bard [2024], Cleric [2024], Warlock [2024], Paladin [2024] (Vengeance)</classes>
     <text>Up to three creatures of your choice that you can see within range must each make a Charisma saving throw. Whenever a target that fails this save makes an attack roll or a saving throw before the spell ends, the target must subtract 1d4 from the attack roll or save.
 
 Using a Higher-Level Spell Slot:
@@ -453,7 +453,7 @@ Source:	Player's Handbook 2024 p. 245</text>
     <range>Self</range>
     <components>V</components>
     <duration>Concentration, up to 1 minute</duration>
-    <classes>Paladin [2024]</classes>
+    <classes>School: Conjuration, Paladin [2024]</classes>
     <text>The target hit by the attack roll takes an extra 5d10 Force damage from the attack. If the attack reduces the target to 50 Hit Points or fewer, the target must succeed on a Charisma saving throw or be transported to a harmless demiplane for the duration. While there, the target has the Incapacitated condition. When the spell ends, the target reappears in the space it left or in the nearest unoccupied space if that space is occupied.
 
 Source:	Player's Handbook 2024 p. 245</text>
@@ -467,7 +467,7 @@ Source:	Player's Handbook 2024 p. 245</text>
     <range>30 feet</range>
     <components>V, S, M (a pentacle)</components>
     <duration>Concentration, up to 1 minute</duration>
-    <classes>Cleric [2024], Sorcerer [2024], Warlock [2024], Wizard [2024], Paladin [2024], Paladin [2024] (Vengeance)</classes>
+    <classes>School: Abjuration, Cleric [2024], Sorcerer [2024], Warlock [2024], Wizard [2024], Paladin [2024], Paladin [2024] (Vengeance)</classes>
     <text>One creature that you can see within range must succeed on a Charisma saving throw or be transported to a harmless demiplane for the duration. While there, the target has the Incapacitated condition. When the spell ends, the target reappears in the space it left or in the nearest unoccupied space if that space is occupied.
 
 If the target is an Aberration, a Celestial, an Elemental, a Fey, or a Fiend, the target doesn't return if the spell lasts for 1 minute. The target is instead transported to a random location on a plane (DM's choice) associated with its creature type.
@@ -485,7 +485,7 @@ Source:	Player's Handbook 2024 p. 245</text>
     <range>Touch</range>
     <components>V, S, M (a handful of oak bark)</components>
     <duration>1 hour</duration>
-    <classes>Druid [2024], Ranger [2024]</classes>
+    <classes>School: Transmutation, Druid [2024], Ranger [2024]</classes>
     <text>You touch a willing creature. Until the spell ends, the target's skin assumes a bark-like appearance, and the target has an Armor Class of 17 if its AC is lower than that.
 
 Source:	Player's Handbook 2024 p. 245</text>
@@ -498,7 +498,7 @@ Source:	Player's Handbook 2024 p. 245</text>
     <range>30 feet</range>
     <components>V, S</components>
     <duration>Concentration, up to 1 minute</duration>
-    <classes>Cleric [2024], Paladin [2024] (Devotion)</classes>
+    <classes>School: Abjuration, Cleric [2024], Paladin [2024] (Devotion)</classes>
     <text>Choose any number of creatures within range. For the duration, each target has Advantage on Wisdom saving throws and Death Saving Throws and regains the maximum number of Hit Points possible from any healing.
 
 Source:	Player's Handbook 2024 p. 245</text>
@@ -512,7 +512,7 @@ Source:	Player's Handbook 2024 p. 245</text>
     <range>Touch</range>
     <components>S</components>
     <duration>Concentration, up to 1 hour</duration>
-    <classes>Druid [2024], Ranger [2024]</classes>
+    <classes>School: Divination, Druid [2024], Ranger [2024]</classes>
     <text>You touch a willing Beast. For the duration, you can perceive through the Beast's senses as well as your own. When perceiving through the Beast's senses, you benefit from any special senses it has.
 
 Source:	Player's Handbook 2024 p. 245</text>
@@ -525,7 +525,7 @@ Source:	Player's Handbook 2024 p. 245</text>
     <range>150 feet</range>
     <components>V, S, M (a key ring with no keys)</components>
     <duration>Instantaneous</duration>
-    <classes>Bard [2024], Druid [2024], Warlock [2024], Wizard [2024]</classes>
+    <classes>School: Enchantment, Bard [2024], Druid [2024], Warlock [2024], Wizard [2024]</classes>
     <text>You blast the mind of a creature that you can see within range. The target makes an Intelligence saving throw.
 
 On a failed save, the target takes 10d12 Psychic damage and can't cast spells or take the Magic action. At the end of every 30 days, the target repeats the save, ending the effect on a success. The effect can also be ended by the Greater Restoration, Heal, or Wish spell.
@@ -543,7 +543,7 @@ Source:	Player's Handbook 2024 p. 245</text>
     <range>Touch</range>
     <components>V, S</components>
     <duration>Concentration, up to 1 minute</duration>
-    <classes>Bard [2024], Cleric [2024], Wizard [2024]</classes>
+    <classes>School: Necromancy, Bard [2024], Cleric [2024], Wizard [2024]</classes>
     <text>You touch a creature, which must succeed on a Wisdom saving throw or become cursed for the duration. Until the curse ends, the target suffers one of the following effects of your choice:
 
 	• Choose one ability. The target has Disadvantage on ability checks and saving throws made with that ability.
@@ -568,7 +568,7 @@ Source:	Player's Handbook 2024 p. 246</text>
     <range>120 feet</range>
     <components>V, S, M (an eggshell and a glove)</components>
     <duration>Concentration, up to 1 minute</duration>
-    <classes>Sorcerer [2024], Wizard [2024]</classes>
+    <classes>School: Evocation, Sorcerer [2024], Wizard [2024]</classes>
     <text>You create a Large hand of shimmering magical energy in an unoccupied space that you can see within range. The hand lasts for the duration, and it moves at your command, mimicking the movements of your own hand.
 
 The hand is an object that has AC 20 and Hit Points equal to your Hit Point maximum. If it drops to 0 Hit Points, the spell ends. The hand doesn't occupy its space.
@@ -610,7 +610,7 @@ Source:	Player's Handbook 2024 p. 246</text>
     <range>90 feet</range>
     <components>V, S</components>
     <duration>Concentration, up to 10 minute</duration>
-    <classes>Cleric [2024]</classes>
+    <classes>School: Evocation, Cleric [2024]</classes>
     <text>You create a wall of whirling blades made of magical energy. The wall appears within range and lasts for the duration. You make a straight wall up to 100 feet long, 20 feet high, and 5 feet thick, or a ringed wall up to 60 feet in diameter, 20 feet high, and 5 feet thick. The wall provides Three-Quarters Cover, and its space is Difficult Terrain.
 
 Any creature in the wall's space makes a Dexterity saving throw, taking 6d10 Force damage on a failed save or half as much damage on a successful one. A creature also makes that save if it enters the wall's space or ends it turn there. A creature makes that save only once per turn.
@@ -626,7 +626,7 @@ Source:	Player's Handbook 2024 p. 247</text>
     <range>Self</range>
     <components>V, S</components>
     <duration>Concentration, up to 1 minute</duration>
-    <classes>Bard [2024], Sorcerer [2024], Warlock [2024], Wizard [2024]</classes>
+    <classes>School: Abjuration, Bard [2024], Sorcerer [2024], Warlock [2024], Wizard [2024]</classes>
     <text>Whenever a creature makes an attack roll against you before the spell ends, the attacker subtracts 1d4 from the attack roll.
 
 Source:	Player's Handbook 2024 p. 247</text>
@@ -640,7 +640,7 @@ Source:	Player's Handbook 2024 p. 247</text>
     <range>30 feet</range>
     <components>V, S, M (a Holy Symbol worth 5+ GP)</components>
     <duration>Concentration, up to 1 minute</duration>
-    <classes>Cleric [2024], Paladin [2024], Cleric [2024] (Life)</classes>
+    <classes>School: Enchantment, Cleric [2024], Paladin [2024], Cleric [2024] (Life)</classes>
     <text>You bless up to three creatures within range. Whenever a target makes an attack roll or a saving throw before the spell ends, the target adds 1d4 to the attack roll or save.
 
 Using a Higher-Level Spell Slot:
@@ -657,7 +657,7 @@ Source:	Player's Handbook 2024 p. 247</text>
     <range>30 feet</range>
     <components>V, S</components>
     <duration>Instantaneous</duration>
-    <classes>Druid [2024], Sorcerer [2024], Warlock [2024], Wizard [2024], Druid [2024] (Arid Land)</classes>
+    <classes>School: Necromancy, Druid [2024], Sorcerer [2024], Warlock [2024], Wizard [2024], Druid [2024] (Arid Land)</classes>
     <text>A creature that you can see within range makes a Constitution saving throw, taking 8d8 Necrotic damage on a failed save or half as much damage on a successful one. A Plant creature automatically fails the save.
 
 Alternatively, target a nonmagical plant that isn't a creature, such as a tree or shrub. It doesn't make a save; it simply withers and dies.
@@ -681,7 +681,7 @@ Source:	Player's Handbook 2024 p. 247</text>
     <range>Self</range>
     <components>V</components>
     <duration>1 minute</duration>
-    <classes>Paladin [2024]</classes>
+    <classes>School: Evocation, Paladin [2024]</classes>
     <text>The target hit by the strike takes an extra 3d8 Radiant damage from the attack, and the target has the Blinded condition until the spell ends. At the end of each of its turns, the Blinded target makes a Constitution saving throw, ending the spell on itself on a success.
 
 Using a Higher-Level Spell Slot:
@@ -704,7 +704,7 @@ Source:	Player's Handbook 2024 p. 247</text>
     <range>30 feet</range>
     <components>V</components>
     <duration>1 minute</duration>
-    <classes>Bard [2024], Cleric [2024], Sorcerer [2024], Wizard [2024]</classes>
+    <classes>School: Transmutation, Bard [2024], Cleric [2024], Sorcerer [2024], Wizard [2024]</classes>
     <text>One creature that you can see within range must succeed on a Constitution saving throw, or it has the Blinded or Deafened condition (your choice) for the duration. At the end of each of its turns, the target repeats the save, ending the spell on itself on a success.
 
 Using a Higher-Level Spell Slot:
@@ -720,7 +720,7 @@ Source:	Player's Handbook 2024 p. 248</text>
     <range>Self</range>
     <components>V, S</components>
     <duration>1 minute</duration>
-    <classes>Sorcerer [2024], Wizard [2024], Warlock [2024] (Archfey)</classes>
+    <classes>School: Transmutation, Sorcerer [2024], Wizard [2024], Warlock [2024] (Archfey)</classes>
     <text>Roll 1d6 at the end of each of your turns for the duration. On a roll of 4-6, you vanish from your current plane of existence and appear in the Ethereal Plane (the spell ends instantly if you are already on that plane). While on the Ethereal Plane, you can perceive the plane you left, which is cast in shades of gray, but you can't see anything there more than 60 feet away. You can affect and be affected only by other creatures on the Ethereal Plane, and creatures on the other plane can't perceive you unless they have a special ability that lets them perceive things on the Ethereal Plane.
 
 You return to the other plane at the start of your next turn and when the spell ends if you are on the Ethereal Plane. You return to an unoccupied space of your choice that you can see within 10 feet of the space you left. If no unoccupied space is available within that range, you appear in the nearest unoccupied space.
@@ -736,7 +736,7 @@ Source:	Player's Handbook 2024 p. 248</text>
     <range>Self</range>
     <components>V</components>
     <duration>Concentration, up to 1 minute</duration>
-    <classes>Sorcerer [2024], Wizard [2024], Druid [2024] (Arid Land)</classes>
+    <classes>School: Illusion, Sorcerer [2024], Wizard [2024], Druid [2024] (Arid Land)</classes>
     <text>Your body becomes blurred. For the duration, any creature has Disadvantage on attack rolls against you. An attacker is immune to this effect if it perceives you with Blindsight or Truesight.
 
 Source:	Player's Handbook 2024 p. 248</text>
@@ -749,7 +749,7 @@ Source:	Player's Handbook 2024 p. 248</text>
     <range>15 feet</range>
     <components>V, S</components>
     <duration>Instantaneous</duration>
-    <classes>Sorcerer [2024], Wizard [2024], Cleric [2024] (Light), Druid [2024] (Arid Land), Warlock [2024] (Fiend)</classes>
+    <classes>School: Evocation, Sorcerer [2024], Wizard [2024], Cleric [2024] (Light), Druid [2024] (Arid Land), Warlock [2024] (Fiend)</classes>
     <text>A thin sheet of flames shoots forth from you. Each creature in a 15-foot Cone makes a Dexterity saving throw, taking 3d6 Fire damage on a failed save or half as much damage on a successful one.
 
 Flammable objects in the Cone that aren't being worn or carried start burning.
@@ -776,7 +776,7 @@ Source:	Player's Handbook 2024 p. 248</text>
     <range>120 feet</range>
     <components>V, S</components>
     <duration>Concentration, up to 10 minute</duration>
-    <classes>Druid [2024]</classes>
+    <classes>School: Conjuration, Druid [2024]</classes>
     <text>A storm cloud appears at a point within range that you can see above yourself. It takes the shape of a Cylinder that is 10 feet tall with a 60-foot radius.
 
 When you cast the spell, choose a point you can see under the cloud. A lightning bolt shoots from the cloud to that point. Each creature within 5 feet of that point makes a Dexterity saving throw, taking 3d10 Lightning damage on a failed save or half as much damage on a successful one.
@@ -805,7 +805,7 @@ Source:	Player's Handbook 2024 p. 248</text>
     <range>60 feet</range>
     <components>V, S</components>
     <duration>Concentration, up to 1 minute</duration>
-    <classes>Bard [2024], Cleric [2024], Sorcerer [2024] (Aberrant), Warlock [2024] (Archfey)</classes>
+    <classes>School: Enchantment, Bard [2024], Cleric [2024], Sorcerer [2024] (Aberrant), Warlock [2024] (Archfey)</classes>
     <text>Each Humanoid in a 20-foot-radius Sphere centered on a point you choose within range must succeed on a Charisma saving throw or be affected by one of the following effects (choose for each creature):
 
 	• The creature has Immunity to the Charmed and Frightened conditions until the spell ends. If the creature was already Charmed or Frightened, those conditions are suppressed for the duration.
@@ -822,7 +822,7 @@ Source:	Player's Handbook 2024 p. 249</text>
     <range>150 feet</range>
     <components>V, S, M (three silver pins)</components>
     <duration>Instantaneous</duration>
-    <classes>Sorcerer [2024], Wizard [2024]</classes>
+    <classes>School: Evocation, Sorcerer [2024], Wizard [2024]</classes>
     <text>You launch a lightning bolt toward a target you can see within range. Three bolts then leap from that target to as many as three other targets of your choice, each of which must be within 30 feet of the first target. A target can be a creature or an object and can be targeted by only one of the bolts.
 
 Each target makes a Dexterity saving throw, taking 10d8 Lightning damage on a failed save or half as much damage on a successful one.
@@ -841,7 +841,7 @@ Source:	Player's Handbook 2024 p. 249</text>
     <range>30 feet</range>
     <components>V, S</components>
     <duration>1 hour</duration>
-    <classes>Bard [2024], Druid [2024], Sorcerer [2024], Warlock [2024], Wizard [2024], Sorcerer [2024] (Draconic)</classes>
+    <classes>School: Enchantment, Bard [2024], Druid [2024], Sorcerer [2024], Warlock [2024], Wizard [2024], Sorcerer [2024] (Draconic)</classes>
     <text>One creature you can see within range makes a Wisdom saving throw. It does so with Advantage if you or your allies are fighting it. On a failed save, the target has the Charmed condition until the spell ends or until you or your allies damage it. The Charmed creature is Friendly to you. When the spell ends, the target knows it was Charmed by you.
 
 Using a Higher-Level Spell Slot:
@@ -857,7 +857,7 @@ Source:	Player's Handbook 2024 p. 249</text>
     <range>30 feet</range>
     <components>V, S</components>
     <duration>1 hour</duration>
-    <classes>Bard [2024], Druid [2024], Sorcerer [2024], Warlock [2024], Wizard [2024], Cleric [2024] (Trickery), Ranger [2024] (Fey Wanderer)</classes>
+    <classes>School: Enchantment, Bard [2024], Druid [2024], Sorcerer [2024], Warlock [2024], Wizard [2024], Cleric [2024] (Trickery), Ranger [2024] (Fey Wanderer)</classes>
     <text>One Humanoid you can see within range makes a Wisdom saving throw. It does so with Advantage if you or your allies are fighting it. On a failed save, the target has the Charmed condition until the spell ends or until you or your allies damage it. The Charmed creature is Friendly to you. When the spell ends, the target knows it was Charmed by you.
 
 Using a Higher-Level Spell Slot:
@@ -873,7 +873,7 @@ Source:	Player's Handbook 2024 p. 249</text>
     <range>Touch</range>
     <components>V, S</components>
     <duration>Instantaneous</duration>
-    <classes>Sorcerer [2024], Warlock [2024], Wizard [2024]</classes>
+    <classes>School: Necromancy, Sorcerer [2024], Warlock [2024], Wizard [2024]</classes>
     <text>Channeling the chill of the grave, make a melee spell attack against a target within reach. On a hit, the target takes 1d10 Necrotic damage, and it can't regain Hit Points until the end of your next turn.
 
 Cantrip Upgrade: The damage increases by 1d10 when you reach levels 5 (2d10), 11 (3d10), and 17 (4d10).
@@ -892,7 +892,7 @@ Source:	Player's Handbook 2024 p. 249</text>
     <range>90 feet</range>
     <components>V, S, M (a diamond worth 50+ GP)</components>
     <duration>Instantaneous</duration>
-    <classes>Sorcerer [2024], Wizard [2024], Sorcerer [2024] (Draconic)</classes>
+    <classes>School: Evocation, Sorcerer [2024], Wizard [2024], Sorcerer [2024] (Draconic)</classes>
     <text>You hurl an orb of energy at a target within range. Choose Acid, Cold, Fire, Lightning, Poison, or Thunder for the type of orb you create, and then make a ranged spell attack against the target. On a hit, the target takes 3d8 damage of the chosen type.
 
 If you roll the same number on two or more of the d8s, the orb leaps to a different target of your choice within 30 feet of the target. Make an attack roll against the new target, and make a new damage roll. The orb can't leap again unless you cast the spell with a level 2+ spell slot.
@@ -919,7 +919,7 @@ Source:	Player's Handbook 2024 p. 249</text>
     <range>150 feet</range>
     <components>V, S, M (the powder of a crushed black pearl worth 500+ GP)</components>
     <duration>Instantaneous</duration>
-    <classes>Sorcerer [2024], Warlock [2024], Wizard [2024]</classes>
+    <classes>School: Necromancy, Sorcerer [2024], Warlock [2024], Wizard [2024]</classes>
     <text>Negative energy ripples out in a 60-foot-radius Sphere from a point you choose within range. Each creature in that area makes a Constitution saving throw, taking 8d8 Necrotic damage on a failed save or half as much damage on a successful one.
 
 Using a Higher-Level Spell Slot:
@@ -939,7 +939,7 @@ Source:	Player's Handbook 2024 p. 250</text>
     <range>Self</range>
     <components>V</components>
     <duration>Concentration, up to 10 minute</duration>
-    <classes>Cleric [2024], Wizard [2024], Paladin [2024]</classes>
+    <classes>School: Abjuration, Cleric [2024], Wizard [2024], Paladin [2024]</classes>
     <text>An aura radiates from you in a 30-foot Emanation for the duration. While in the aura, you and your allies have Advantage on saving throws against spells and other magical effects. When an affected creature makes a saving throw against a spell or magical effect that allows a save to take only half damage, it takes no damage if it succeeds on the save.
 
 Source:	Player's Handbook 2024 p. 250</text>
@@ -952,7 +952,7 @@ Source:	Player's Handbook 2024 p. 250</text>
     <range>1 Miles</range>
     <components>V, S, M (a focus worth 100+ GP, either a jeweled horn for hearing or a glass eye for seeing)</components>
     <duration>Concentration, up to 10 minute</duration>
-    <classes>Bard [2024], Cleric [2024], Sorcerer [2024], Wizard [2024], Warlock [2024] (Great Old One)</classes>
+    <classes>School: Divination, Bard [2024], Cleric [2024], Sorcerer [2024], Wizard [2024], Warlock [2024] (Great Old One)</classes>
     <text>You create an Invisible sensor within range in a location familiar to you (a place you have visited or seen before) or in an obvious location that is unfamiliar to you (such as behind a door, around a corner, or in a grove of trees). The intangible, invulnerable sensor remains in place for the duration.
 
 When you cast the spell, choose seeing or hearing. You can use the chosen sense through the sensor as if you were in its space. As a Bonus Action, you can switch between seeing and hearing.
@@ -969,7 +969,7 @@ Source:	Player's Handbook 2024 p. 250</text>
     <range>Touch</range>
     <components>V, S, M (a diamond worth 1,000+ GP, which the spell consumes, and a sealable vessel worth 2,000+ GP that is large enough to hold the creature being cloned)</components>
     <duration>Instantaneous</duration>
-    <classes>Wizard [2024]</classes>
+    <classes>School: Necromancy, Wizard [2024]</classes>
     <text>You touch a creature or at least 1 cubic inch of its flesh. An inert duplicate of that creature forms inside the vessel used in the spell's casting and finishes growing after 120 days; you choose whether the finished clone is the same age as the creature or younger. The clone remains inert and endures indefinitely while its vessel remains undisturbed.
 
 If the original creature dies after the clone finishes forming, the creature's soul transfers to the clone if the soul is free and willing to return. The clone is physically identical to the original and has the same personality, memories, and abilities, but none of the original's equipment. The creature's original remains, if any, become inert and can't be revived, since the creature's soul is elsewhere.
@@ -984,7 +984,7 @@ Source:	Player's Handbook 2024 p. 251</text>
     <range>60 feet</range>
     <components>V, S, M (a sliver of glass)</components>
     <duration>Concentration, up to 1 minute</duration>
-    <classes>Bard [2024], Sorcerer [2024], Warlock [2024], Wizard [2024]</classes>
+    <classes>School: Conjuration, Bard [2024], Sorcerer [2024], Warlock [2024], Wizard [2024]</classes>
     <text>You conjure spinning daggers in a 5-foot Cube centered on a point within range. Each creature in that area takes 4d4 Slashing damage. A creature also takes this damage if it enters the Cube or ends its turn there or if the Cube moves into its space. A creature takes this damage only once per turn.
 
 On your later turns, you can take a Magic action to teleport the Cube up to 30 feet.
@@ -1010,7 +1010,7 @@ Source:	Player's Handbook 2024 p. 251</text>
     <range>120 feet</range>
     <components>V, S</components>
     <duration>Concentration, up to 10 minute</duration>
-    <classes>Sorcerer [2024], Wizard [2024]</classes>
+    <classes>School: Conjuration, Sorcerer [2024], Wizard [2024]</classes>
     <text>You create a 20-foot-radius Sphere of yellow-green fog centered on a point within range. The fog lasts for the duration or until strong wind (such as the one created by Gust of Wind) disperses it, ending the spell. Its area is Heavily Obscured.
 
 Each creature in the Sphere makes a Constitution saving throw, taking 5d8 Poison damage on a failed save or half as much damage on a successful one. A creature must also make this save when the Sphere moves into its space and when it enters the Sphere or ends its turn there. A creature makes this save only once per turn.
@@ -1035,7 +1035,7 @@ Source:	Player's Handbook 2024 p. 251</text>
     <range>15 feet</range>
     <components>V, S, M (a pinch of colorful sand)</components>
     <duration>Instantaneous</duration>
-    <classes>Bard [2024], Sorcerer [2024], Wizard [2024]</classes>
+    <classes>School: Illusion, Bard [2024], Sorcerer [2024], Wizard [2024]</classes>
     <text>You launch a dazzling array of flashing, colorful light. Each creature in a 15-foot Cone originating from you must succeed on a Constitution saving throw or have the Blinded condition until the end of your next turn.
 
 Source:	Player's Handbook 2024 p. 251</text>
@@ -1048,7 +1048,7 @@ Source:	Player's Handbook 2024 p. 251</text>
     <range>60 feet</range>
     <components>V</components>
     <duration>Instantaneous</duration>
-    <classes>Bard [2024], Cleric [2024], Paladin [2024], Sorcerer [2024] (Draconic), Warlock [2024] (Fiend)</classes>
+    <classes>School: Enchantment, Bard [2024], Cleric [2024], Paladin [2024], Sorcerer [2024] (Draconic), Warlock [2024] (Fiend)</classes>
     <text>You speak a one-word command to a creature you can see within range. The target must succeed on a Wisdom saving throw or follow the command on its next turn. Choose the command from these options:
 
 Approach:
@@ -1080,7 +1080,7 @@ Source:	Player's Handbook 2024 p. 251</text>
     <range>Self</range>
     <components>V, S, M (incense)</components>
     <duration>1 minute</duration>
-    <classes>Cleric [2024], Paladin [2024] (Devotion), Paladin [2024] (Ancient)</classes>
+    <classes>School: Divination, Cleric [2024], Paladin [2024] (Devotion), Paladin [2024] (Ancient)</classes>
     <text>You contact a deity or a divine proxy and ask up to three questions that can be answered with yes or no. You must ask your questions before the spell ends. You receive a correct answer for each question.
 
 Divine beings aren't necessarily omniscient, so you might receive "unclear" as an answer if a question pertains to information that lies beyond the deity's knowledge. In a case where a one-word answer could be misleading or contrary to the deity's interests, the DM might offer a short phrase as an answer instead.
@@ -1098,7 +1098,7 @@ Source:	Player's Handbook 2024 p. 252</text>
     <range>Self</range>
     <components>V, S</components>
     <duration>1 minute</duration>
-    <classes>Druid [2024], Ranger [2024], Paladin [2024] (Ancient)</classes>
+    <classes>School: Divination, Druid [2024], Ranger [2024], Paladin [2024] (Ancient)</classes>
     <text>You commune with nature spirits and gain knowledge of the surrounding area. In the outdoors, the spell gives you knowledge of the area within 3 miles of you. In caves and other natural underground settings, the radius is limited to 300 feet. The spell doesn't function where nature has been replaced by construction, such as in castles and settlements.
 
 Choose three of the following facts; you learn those facts as they pertain to the spell's area:
@@ -1125,7 +1125,7 @@ Source:	Player's Handbook 2024 p. 252</text>
     <range>30 feet</range>
     <components>V</components>
     <duration>Concentration, up to 1 minute</duration>
-    <classes>Paladin [2024]</classes>
+    <classes>School: Enchantment, Paladin [2024]</classes>
     <text>You try to compel a creature into a duel. One creature that you can see within range makes a Wisdom saving throw. On a failed save, the target has Disadvantage on attack rolls against creatures other than you, and it can't willingly move to a space that is more than 30 feet away from you.
 
 The spell ends if you make an attack roll against a creature other than the target, if you cast a spell on an enemy other than the target, if an ally of yours damages the target, or if you end your turn more than 30 feet away from the target.
@@ -1141,7 +1141,7 @@ Source:	Player's Handbook 2024 p. 252</text>
     <range>Self</range>
     <components>V, S, M (a pinch of soot and salt)</components>
     <duration>1 hour</duration>
-    <classes>Bard [2024], Sorcerer [2024], Warlock [2024], Wizard [2024]</classes>
+    <classes>School: Divination, Bard [2024], Sorcerer [2024], Warlock [2024], Wizard [2024]</classes>
     <text>For the duration, you understand the literal meaning of any language that you hear or see signed. You also understand any written language that you see, but you must be touching the surface on which the words are written. It takes about 1 minute to read one page of text. This spell doesn't decode symbols or secret messages.
 
 Source:	Player's Handbook 2024 p. 252</text>
@@ -1154,7 +1154,7 @@ Source:	Player's Handbook 2024 p. 252</text>
     <range>30 feet</range>
     <components>V, S</components>
     <duration>Concentration, up to 1 minute</duration>
-    <classes>Bard [2024], Paladin [2024] (Glory)</classes>
+    <classes>School: Enchantment, Bard [2024], Paladin [2024] (Glory)</classes>
     <text>Each creature of your choice that you can see within range must succeed on a Wisdom saving throw or have the Charmed condition until the spell ends.
 
 For the duration, you can take a Bonus Action to designate a direction that is horizontal to you. Each Charmed target must use as much of its movement as possible to move in that direction on its next turn, taking the safest route. After moving in this way, a target repeats the save, ending the spell on itself on a success.
@@ -1169,7 +1169,7 @@ Source:	Player's Handbook 2024 p. 252</text>
     <range>60 feet</range>
     <components>V, S, M (a small crystal or glass cone)</components>
     <duration>Instantaneous</duration>
-    <classes>Druid [2024], Sorcerer [2024], Wizard [2024], Druid [2024] (Polar Land)</classes>
+    <classes>School: Evocation, Druid [2024], Sorcerer [2024], Wizard [2024], Druid [2024] (Polar Land)</classes>
     <text>You unleash a blast of cold air. Each creature in a 60-foot Cone originating from you makes a Constitution saving throw, taking 8d8 Cold damage on a failed save or half as much damage on a successful one. A creature killed by this spell becomes a frozen statue until it thaws.
 
 Using a Higher-Level Spell Slot:
@@ -1190,7 +1190,7 @@ Source:	Player's Handbook 2024 p. 253</text>
     <range>90 feet</range>
     <components>V, S, M (three nut shells)</components>
     <duration>Concentration, up to 1 minute</duration>
-    <classes>Bard [2024], Druid [2024], Sorcerer [2024], Wizard [2024], Cleric [2024] (Trickery), Warlock [2024] (Great Old One)</classes>
+    <classes>School: Enchantment, Bard [2024], Druid [2024], Sorcerer [2024], Wizard [2024], Cleric [2024] (Trickery), Warlock [2024] (Great Old One)</classes>
     <text>Each creature in a 10-foot-radius Sphere centered on a point you choose within range must succeed on a Wisdom saving throw, or that target can't take Bonus Actions or Reactions and must roll 1d10 at the start of each of its turns to determine its behavior for that turn, consulting the table below.
 
 Confused Actions:
@@ -1217,7 +1217,7 @@ Source:	Player's Handbook 2024 p. 253</text>
     <range>60 feet</range>
     <components>V, S</components>
     <duration>Concentration, up to 10 minute</duration>
-    <classes>Druid [2024], Ranger [2024], Druid [2024] (Moon)</classes>
+    <classes>School: Conjuration, Druid [2024], Ranger [2024], Druid [2024] (Moon)</classes>
     <text>You conjure nature spirits that appear as a Large pack of spectral, intangible animals in an unoccupied space you can see within range. The pack lasts for the duration, and you choose the spirits' animal form, such as wolves, serpents, or birds.
 
 You have Advantage on Strength saving throws while you're within 5 feet of the pack, and when you move on your turn, you can also move the pack up to 30 feet to an unoccupied space you can see.
@@ -1244,7 +1244,7 @@ Source:	Player's Handbook 2024 p. 254</text>
     <range>60 feet</range>
     <components>V, S, M (a Melee or Ranged weapon worth at least 1 CP)</components>
     <duration>Instantaneous</duration>
-    <classes>Ranger [2024]</classes>
+    <classes>School: Conjuration, Ranger [2024]</classes>
     <text>You brandish the weapon used to cast the spell and conjure similar spectral weapons (or ammunition appropriate to the weapon) that launch forward and then disappear. Each creature of your choice that you can see in a 60-foot Cone makes a Dexterity saving throw, taking 5d8 Force damage on a failed save or half as much damage on a successful one.
 
 Using a Higher-Level Spell Slot:
@@ -1267,7 +1267,7 @@ Source:	Player's Handbook 2024 p. 254</text>
     <range>90 feet</range>
     <components>V, S</components>
     <duration>Concentration, up to 10 minute</duration>
-    <classes>Cleric [2024]</classes>
+    <classes>School: Conjuration, Cleric [2024]</classes>
     <text>You conjure a spirit from the Upper Planes, which manifests as a pillar of light in a 10-foot-radius, 40-foot-high Cylinder centered on a point within range. For each creature you can see in the Cylinder, choose which of these lights shines on it:
 
 Healing Light:
@@ -1293,7 +1293,7 @@ Source:	Player's Handbook 2024 p. 254</text>
     <range>60 feet</range>
     <components>V, S</components>
     <duration>Concentration, up to 10 minute</duration>
-    <classes>Druid [2024], Wizard [2024], Druid [2024] (Sea)</classes>
+    <classes>School: Conjuration, Druid [2024], Wizard [2024], Druid [2024] (Sea)</classes>
     <text>You conjure a Large, intangible spirit from the Elemental Planes that appears in an unoccupied space within range. Choose the spirit's element, which determines its damage type: air (Lightning), earth (Thunder), fire (Fire), or water (Cold). The spirit lasts for the duration.
 
 Whenever a creature you can see enters the spirit's space or starts its turn within 5 feet of the spirit, you can force that creature to make a Dexterity saving throw if the spirit has no creature Restrained. On failed save, the target takes 8d8 damage of the spirit's type, and the target has the Restrained condition until the spell ends. At the start of each of its turns, the Restrained target repeats the save. On a failed save, the target takes 4d8 damage of the spirit's type. On a successful save, the target isn't Restrained by the spirit.
@@ -1317,7 +1317,7 @@ Source:	Player's Handbook 2024 p. 254</text>
     <range>60 feet</range>
     <components>V, S</components>
     <duration>Concentration, up to 10 minute</duration>
-    <classes>Druid [2024]</classes>
+    <classes>School: Conjuration, Druid [2024]</classes>
     <text>You conjure a Medium spirit from the Feywild in an unoccupied space you can see within range. The spirit lasts for the duration, and it looks like a Fey creature of your choice. When the spirit appears, you can make one melee spell attack against a creature within 5 feet of it. On a hit, the target takes Psychic damage equal to 3d12 plus your spellcasting ability modifier, and the target has the Frightened condition until the start of your next turn, with both you and the spirit as the source of the fear.
 
 As a Bonus Action on your later turns, you can teleport the spirit to an unoccupied space you can see within 30 feet of the space it left and make the attack against a creature within 5 feet of it.
@@ -1339,7 +1339,7 @@ Source:	Player's Handbook 2024 p. 255</text>
     <range>Self</range>
     <components>V, S</components>
     <duration>Concentration, up to 10 minute</duration>
-    <classes>Druid [2024], Wizard [2024]</classes>
+    <classes>School: Conjuration, Druid [2024], Wizard [2024]</classes>
     <text>You conjure spirits from the Elemental Planes that flit around you in a 15-foot Emanation for the duration. Until the spell ends, any attack you make deals an extra 2d8 damage when you hit a creature in the Emanation. This damage is Acid, Cold, Fire, or Lightning (your choice when you make the attack).
 
 In addition, the ground in the Emanation is Difficult Terrain for your enemies.
@@ -1363,7 +1363,7 @@ Source:	Player's Handbook 2024 p. 255</text>
     <range>150 feet</range>
     <components>V, S, M (a Melee or Ranged weapon worth at least 1 CP)</components>
     <duration>Instantaneous</duration>
-    <classes>Ranger [2024]</classes>
+    <classes>School: Conjuration, Ranger [2024]</classes>
     <text>You brandish the weapon used to cast the spell and choose a point within range. Hundreds of similar spectral weapons (or ammunition appropriate to the weapon) fall in a volley and then disappear. Each creature of your choice that you can see in a 40-foot-radius, 20-foot-high Cylinder centered on that point makes a Dexterity saving throw. A creature takes 8d8 Force damage on a failed save or half as much damage on a successful one.
 
 Source:	Player's Handbook 2024 p. 255</text>
@@ -1377,7 +1377,7 @@ Source:	Player's Handbook 2024 p. 255</text>
     <range>Self</range>
     <components>V, S</components>
     <duration>Concentration, up to 10 minute</duration>
-    <classes>Druid [2024], Ranger [2024]</classes>
+    <classes>School: Conjuration, Druid [2024], Ranger [2024]</classes>
     <text>You conjure nature spirits that flit around you in a 10-foot Emanation for the duration. Whenever the Emanation enters the space of a creature you can see and whenever a creature you can see enters the Emanation or ends its turn there, you can force that creature to make a Wisdom saving throw. The creature takes 5d8 Force damage on a failed save or half as much damage on a successful one. A creature makes this save only once per turn.
 
 In addition, you can take the Disengage action as a Bonus Action for the spell's duration.
@@ -1402,7 +1402,7 @@ Source:	Player's Handbook 2024 p. 255</text>
     <range>Self</range>
     <components>V</components>
     <duration>1 minute</duration>
-    <classes>Warlock [2024], Wizard [2024]</classes>
+    <classes>School: Divination, Warlock [2024], Wizard [2024]</classes>
     <text>You mentally contact a demigod, the spirit of a long-dead sage, or some other knowledgeable entity from another plane. Contacting this otherworldly intelligence can break your mind. When you cast this spell, make a DC 15 Intelligence saving throw. On a successful save, you can ask the entity up to five questions. You must ask your questions before the spell ends. The DM answers each question with one word, such as "yes," "no," "maybe," "never," "irrelevant," or "unclear" (if the entity doesn't know the answer to the question). If a one-word answer would be misleading, the DM might instead offer a short phrase as an answer.
 
 On a failed save, you take 6d6 Psychic damage and have the Incapacitated condition until you finish a Long Rest. A Greater Restoration spell cast on you ends this effect.
@@ -1418,7 +1418,7 @@ Source:	Player's Handbook 2024 p. 255</text>
     <range>Touch</range>
     <components>V, S</components>
     <duration>7 day</duration>
-    <classes>Cleric [2024], Druid [2024]</classes>
+    <classes>School: Necromancy, Cleric [2024], Druid [2024]</classes>
     <text>Your touch inflicts a magical contagion. The target must succeed on a Constitution saving throw or take 11d8 Necrotic damage and have the Poisoned condition. Also, choose one ability when you cast the spell. While Poisoned, the target has Disadvantage on saving throws made with the chosen ability.
 
 The target must repeat the saving throw at the end of each of its turns until it gets three successes or failures. If the target succeeds on three of these saves, the spell ends on the target. If the target fails three of the saves, the spell lasts for 7 days on it.
@@ -1436,7 +1436,7 @@ Source:	Player's Handbook 2024 p. 256</text>
     <range>Self</range>
     <components>V, S, M (a gem-encrusted statuette of yourself worth 1,500+ GP)</components>
     <duration>10 day</duration>
-    <classes>Wizard [2024]</classes>
+    <classes>School: Abjuration, Wizard [2024]</classes>
     <text>Choose a spell of level 5 or lower that you can cast, that has a casting time of an action, and that can target you. You cast that spell—called the contingent spell—as part of casting Contingency, expending spell slots for both, but the contingent spell doesn't come into effect. Instead, it takes effect when a certain trigger occurs. You describe that trigger when you cast the two spells. For example, a Contingency cast with Water Breathing might stipulate that Water Breathing comes into effect when you are engulfed in water or a similar liquid.
 
 The contingent spell takes effect immediately after the trigger occurs for the first time, whether or not you want it to, and then Contingency ends.
@@ -1453,7 +1453,7 @@ Source:	Player's Handbook 2024 p. 256</text>
     <range>Touch</range>
     <components>V, S, M (ruby dust worth 50+ GP, which the spell consumes)</components>
     <duration/>
-    <classes>Cleric [2024], Druid [2024], Wizard [2024]</classes>
+    <classes>School: Evocation, Cleric [2024], Druid [2024], Wizard [2024]</classes>
     <text>A flame springs from an object that you touch. The effect casts Bright Light in a 20-foot radius and Dim Light for an additional 20 feet. It looks like a regular flame, but it creates no heat and consumes no fuel. The flame can be covered or hidden but not smothered or quenched.
 
 Source:	Player's Handbook 2024 p. 256</text>
@@ -1466,7 +1466,7 @@ Source:	Player's Handbook 2024 p. 256</text>
     <range>300 feet</range>
     <components>V, S, M (a mixture of water and dust)</components>
     <duration>Concentration, up to 10 minute</duration>
-    <classes>Cleric [2024], Druid [2024], Wizard [2024], Druid [2024] (Sea)</classes>
+    <classes>School: Transmutation, Cleric [2024], Druid [2024], Wizard [2024], Druid [2024] (Sea)</classes>
     <text>Until the spell ends, you control any water inside an area you choose that is a Cube up to 100 feet on a side, using one of the following effects. As a Magic action on your later turns, you can repeat the same effect or choose a different one.
 
 Flood:
@@ -1494,7 +1494,7 @@ Source:	Player's Handbook 2024 p. 256</text>
     <range>5 Miles</range>
     <components>V, S, M (burning incense)</components>
     <duration>Concentration, up to 8 hour</duration>
-    <classes>Cleric [2024], Druid [2024], Wizard [2024]</classes>
+    <classes>School: Transmutation, Cleric [2024], Druid [2024], Wizard [2024]</classes>
     <text>You take control of the weather within 5 miles of you for the duration. You must be outdoors to cast this spell, and it ends early if you go indoors.
 
 When you cast the spell, you change the current weather conditions, which are determined by the DM. You can change precipitation, temperature, and wind. It takes 1d4 x 10 minutes for the new conditions to take effect. Once they do so, you can change the conditions again. When the spell ends, the weather gradually returns to normal.
@@ -1534,7 +1534,7 @@ Source:	Player's Handbook 2024 p. 257</text>
     <range>Touch</range>
     <components>V, S, M (four or more arrows or bolts)</components>
     <duration>8 hour</duration>
-    <classes>Ranger [2024]</classes>
+    <classes>School: Transmutation, Ranger [2024]</classes>
     <text>You touch up to four nonmagical Arrows or Bolts and plant them in the ground in your space. Until the spell ends, the ammunition can't be physically uprooted, and whenever a creature other than you enters a space within 30 feet of the ammunition for the first time on a turn or ends its turn there, one piece of ammunition flies up to strike it. The creature must succeed on a Dexterity saving throw or take 2d4 Piercing damage. The piece of ammunition is then destroyed. The spell ends when none of the ammunition remains planted in the ground.
 
 When you cast this spell, you can designate any creatures you choose, and the spell ignores them.
@@ -1553,7 +1553,7 @@ Source:	Player's Handbook 2024 p. 258</text>
     <range>60 feet</range>
     <components>S</components>
     <duration>Instantaneous</duration>
-    <classes>Sorcerer [2024], Warlock [2024], Wizard [2024]</classes>
+    <classes>School: Abjuration, Sorcerer [2024], Warlock [2024], Wizard [2024]</classes>
     <text>You attempt to interrupt a creature in the process of casting a spell. The creature makes a Constitution saving throw. On a failed save, the spell dissipates with no effect, and the action, Bonus Action, or Reaction used to cast it is wasted. If that spell was cast with a spell slot, the slot isn't expended.
 
 Source:	Player's Handbook 2024 p. 258</text>
@@ -1566,7 +1566,7 @@ Source:	Player's Handbook 2024 p. 258</text>
     <range>30 feet</range>
     <components>V, S</components>
     <duration>Instantaneous</duration>
-    <classes>Cleric [2024], Paladin [2024]</classes>
+    <classes>School: Conjuration, Cleric [2024], Paladin [2024]</classes>
     <text>You create 45 pounds of food and 30 gallons of fresh water on the ground or in containers within range—both useful in fending off the hazards of malnutrition and dehydration. The food is bland but nourishing and looks like a food of your choice, and the water is clean. The food spoils after 24 hours if uneaten.
 
 Source:	Player's Handbook 2024 p. 258</text>
@@ -1579,7 +1579,7 @@ Source:	Player's Handbook 2024 p. 258</text>
     <range>30 feet</range>
     <components>V, S, M (a mix of water and sand)</components>
     <duration>Instantaneous</duration>
-    <classes>Cleric [2024]</classes>
+    <classes>School: Transmutation, Cleric [2024]</classes>
     <text>You do one of the following:
 
 Create Water:
@@ -1601,7 +1601,7 @@ Source:	Player's Handbook 2024 p. 258</text>
     <range>10 feet</range>
     <components>V, S, M (one 150+ GP black onyx stone for each corpse)</components>
     <duration>Instantaneous</duration>
-    <classes>Cleric [2024], Warlock [2024], Wizard [2024]</classes>
+    <classes>School: Necromancy, Cleric [2024], Warlock [2024], Wizard [2024]</classes>
     <text>You can cast this spell only at night. Choose up to three corpses of Medium or Small Humanoids within range. Each one becomes a Ghoul under your control (see the the XMM for its stat block).
 
 As a Bonus Action on each of your turns, you can mentally command any creature you animated with this spell if the creature is within 120 feet of you (if you control multiple creatures, you can command any of them at the same time, issuing the same command to them). You decide what action the creature will take and where it will move on its next turn, or you can issue a general command, such as to guard a particular place. If you issue no commands, the creature takes the Dodge action and moves only to avoid harm. Once given an order, the creature continues to follow the order until its task is complete.
@@ -1621,7 +1621,7 @@ Source:	Player's Handbook 2024 p. 258</text>
     <range>30 feet</range>
     <components>V, S, M (a paintbrush)</components>
     <duration/>
-    <classes>Sorcerer [2024], Wizard [2024]</classes>
+    <classes>School: Illusion, Sorcerer [2024], Wizard [2024]</classes>
     <text>You pull wisps of shadow material from the Shadowfell to create an object within range. It is either an object of vegetable matter (soft goods, rope, wood, and the like) or mineral matter (stone, crystal, metal, and the like). The object must be no larger than a 5-foot Cube, and the object must be of a form and material that you have seen.
 
 The spell's duration depends on the object's material, as shown in the Materials table. If the object is composed of multiple materials, use the shortest duration. Using any object created by this spell as another spell's Material component causes the other spell to fail.
@@ -1646,7 +1646,7 @@ Source:	Player's Handbook 2024 p. 259</text>
     <range>120 feet</range>
     <components>V, S</components>
     <duration>Concentration, up to 1 minute</duration>
-    <classes>Bard [2024], Sorcerer [2024], Warlock [2024], Wizard [2024]</classes>
+    <classes>School: Enchantment, Bard [2024], Sorcerer [2024], Warlock [2024], Wizard [2024]</classes>
     <text>One creature that you can see within range must succeed on a Wisdom saving throw or have the Charmed condition for the duration. The creature succeeds automatically if it isn't Humanoid.
 
 A spectral crown appears on the Charmed target's head, and it must use its action before moving on each of its turns to make a melee attack against a creature other than itself that you mentally choose. The target can act normally on its turn if you choose no creature or if no creature is within its reach. The target repeats the save at the end of each of its turns, ending the spell on itself on a success.
@@ -1663,7 +1663,7 @@ Source:	Player's Handbook 2024 p. 259</text>
     <range>Self</range>
     <components>V</components>
     <duration>Concentration, up to 1 minute</duration>
-    <classes>Paladin [2024], Cleric [2024] (War)</classes>
+    <classes>School: Evocation, Paladin [2024], Cleric [2024] (War)</classes>
     <text>You radiate a magical aura in a 30-foot Emanation. While in the aura, you and your allies each deal an extra 1d4 Radiant damage when hitting with a weapon or an Unarmed Strike.
 
 Source:	Player's Handbook 2024 p. 259</text>
@@ -1677,7 +1677,7 @@ Source:	Player's Handbook 2024 p. 259</text>
     <range>Touch</range>
     <components>V, S</components>
     <duration>Instantaneous</duration>
-    <classes>Bard [2024], Cleric [2024], Druid [2024], Ranger [2024], Paladin [2024], Cleric [2024] (Life), Druid [2024] (Moon), Warlock [2024] (Celestial)</classes>
+    <classes>School: Abjuration, Bard [2024], Cleric [2024], Druid [2024], Ranger [2024], Paladin [2024], Cleric [2024] (Life), Druid [2024] (Moon), Warlock [2024] (Celestial)</classes>
     <text>A creature you touch regains a number of Hit Points equal to 2d8 plus your spellcasting ability modifier.
 
 Using a Higher-Level Spell Slot:
@@ -1702,7 +1702,7 @@ Source:	Player's Handbook 2024 p. 259</text>
     <range>120 feet</range>
     <components>V, S, M (a bit of phosphorus)</components>
     <duration>Concentration, up to 1 minute</duration>
-    <classes>Bard [2024], Sorcerer [2024], Wizard [2024]</classes>
+    <classes>School: Illusion, Bard [2024], Sorcerer [2024], Wizard [2024]</classes>
     <text>You create up to four torch-size lights within range, making them appear as torches, lanterns, or glowing orbs that hover for the duration. Alternatively, you combine the four lights into one glowing Medium form that is vaguely humanlike. Whichever form you choose, each light sheds Dim Light in a 10-foot radius.
 
 As a Bonus Action, you can move the lights up to 60 feet to a space within range. A light must be within 20 feet of another light created by this spell, and a light vanishes if it exceeds the spell's range.
@@ -1717,7 +1717,7 @@ Source:	Player's Handbook 2024 p. 259</text>
     <range>60 feet</range>
     <components>V, M (bat fur and a piece of coal)</components>
     <duration>Concentration, up to 10 minute</duration>
-    <classes>Sorcerer [2024], Warlock [2024], Wizard [2024]</classes>
+    <classes>School: Evocation, Sorcerer [2024], Warlock [2024], Wizard [2024]</classes>
     <text>For the duration, magical Darkness spreads from a point within range and fills a 15-foot-radius Sphere. Darkvision can't see through it, and nonmagical light can't illuminate it.
 
 Alternatively, you cast the spell on an object that isn't being worn or carried, causing the Darkness to fill a 15-foot Emanation originating from that object. Covering that object with something opaque, such as a bowl or helm, blocks the Darkness.
@@ -1734,7 +1734,7 @@ Source:	Player's Handbook 2024 p. 260</text>
     <range>Touch</range>
     <components>V, S, M (a dried carrot)</components>
     <duration>8 hour</duration>
-    <classes>Druid [2024], Ranger [2024], Sorcerer [2024], Wizard [2024]</classes>
+    <classes>School: Transmutation, Druid [2024], Ranger [2024], Sorcerer [2024], Wizard [2024]</classes>
     <text>For the duration, a willing creature you touch has Darkvision with a range of 150 feet.
 
 Source:	Player's Handbook 2024 p. 260</text>
@@ -1747,7 +1747,7 @@ Source:	Player's Handbook 2024 p. 260</text>
     <range>60 feet</range>
     <components>V, S</components>
     <duration>1 hour</duration>
-    <classes>Cleric [2024], Druid [2024], Ranger [2024], Sorcerer [2024], Paladin [2024], Cleric [2024] (Light), Warlock [2024] (Celestial)</classes>
+    <classes>School: Evocation, Cleric [2024], Druid [2024], Ranger [2024], Sorcerer [2024], Paladin [2024], Cleric [2024] (Light), Warlock [2024] (Celestial)</classes>
     <text>For the duration, sunlight spreads from a point within range and fills a 60-foot-radius Sphere. The sunlight's area is Bright Light and sheds Dim Light for an additional 60 feet.
 
 Alternatively, you cast the spell on an object that isn't being worn or carried, causing the sunlight to fill a 60-foot Emanation originating from that object. Covering that object with something opaque, such as a bowl or helm, blocks the sunlight.
@@ -1764,7 +1764,7 @@ Source:	Player's Handbook 2024 p. 260</text>
     <range>Touch</range>
     <components>V, S</components>
     <duration>8 hour</duration>
-    <classes>Cleric [2024], Paladin [2024], Cleric [2024] (Life)</classes>
+    <classes>School: Abjuration, Cleric [2024], Paladin [2024], Cleric [2024] (Life)</classes>
     <text>You touch a creature and grant it a measure of protection from death. The first time the target would drop to 0 Hit Points before the spell ends, the target instead drops to 1 Hit Point, and the spell ends.
 
 If the spell is still in effect when the target is subjected to an effect that would kill it instantly without dealing damage, that effect is negated against the target, and the spell ends.
@@ -1779,7 +1779,7 @@ Source:	Player's Handbook 2024 p. 261</text>
     <range>150 feet</range>
     <components>V, S, M (a ball of bat guano and sulfur)</components>
     <duration>Concentration, up to 1 minute</duration>
-    <classes>Sorcerer [2024], Wizard [2024]</classes>
+    <classes>School: Evocation, Sorcerer [2024], Wizard [2024]</classes>
     <text>A beam of yellow light flashes from you, then condenses at a chosen point within range as a glowing bead for the duration. When the spell ends, the bead explodes, and each creature in a 20-foot-radius Sphere centered on that point makes a Dexterity saving throw. A creature takes Fire damage equal to the total accumulated damage on a failed save or half as much damage on a successful one.
 
 The spell's base damage is 12d6, and the damage increases by 1d6 whenever your turn ends and the spell hasn't ended.
@@ -1805,7 +1805,7 @@ Source:	Player's Handbook 2024 p. 261</text>
     <range>60 feet</range>
     <components>S</components>
     <duration>1 hour</duration>
-    <classes>Sorcerer [2024], Warlock [2024], Wizard [2024]</classes>
+    <classes>School: Conjuration, Sorcerer [2024], Warlock [2024], Wizard [2024]</classes>
     <text>You create a shadowy Medium door on a flat solid surface that you can see within range. This door can be opened and closed, and it leads to a demiplane that is an empty room 30 feet in each dimension, made of wood or stone (your choice).
 
 When the spell ends, the door vanishes, and any objects inside the demiplane remain there. Any creatures inside also remain unless they opt to be shunted through the door as it vanishes, landing with the Prone condition in the unoccupied spaces closest to the door's former space.
@@ -1822,7 +1822,7 @@ Source:	Player's Handbook 2024 p. 261</text>
     <range>30 feet</range>
     <components>V</components>
     <duration>Instantaneous</duration>
-    <classes>Paladin [2024]</classes>
+    <classes>School: Evocation, Paladin [2024]</classes>
     <text>Destructive energy ripples outward from you in a 30-foot Emanation. Each creature you choose in the Emanation makes a Constitution saving throw. On a failed save, a target takes 5d6 Thunder damage and 5d6 Radiant or Necrotic damage (your choice) and has the Prone condition. On a successful save, a target takes half as much damage only.
 
 Source:	Player's Handbook 2024 p. 261</text>
@@ -1837,7 +1837,7 @@ Source:	Player's Handbook 2024 p. 261</text>
     <range>30 feet</range>
     <components>V, S</components>
     <duration>Concentration, up to 10 minute</duration>
-    <classes>Cleric [2024], Paladin [2024]</classes>
+    <classes>School: Divination, Cleric [2024], Paladin [2024]</classes>
     <text>For the duration, you sense the location of any Aberration, Celestial, Elemental, Fey, Fiend, or Undead within 30 feet of yourself. You also sense whether the Hallow spell is active there and, if so, where.
 
 The spell is blocked by 1 foot of stone, dirt, or wood; 1 inch of metal; or a thin sheet of lead.
@@ -1853,7 +1853,7 @@ Source:	Player's Handbook 2024 p. 261</text>
     <range>30 feet</range>
     <components>V, S</components>
     <duration>Concentration, up to 10 minute</duration>
-    <classes>Bard [2024], Cleric [2024], Druid [2024], Ranger [2024], Sorcerer [2024], Warlock [2024], Wizard [2024], Paladin [2024]</classes>
+    <classes>School: Divination, Bard [2024], Cleric [2024], Druid [2024], Ranger [2024], Sorcerer [2024], Warlock [2024], Wizard [2024], Paladin [2024]</classes>
     <text>For the duration, you sense the presence of magical effects within 30 feet of yourself. If you sense such effects, you can take the Magic action to see a faint aura around any visible creature or object in the area that bears the magic, and if an effect was created by a spell, you learn the spell's the Player's Handbook 2024.
 
 The spell is blocked by 1 foot of stone, dirt, or wood; 1 inch of metal; or a thin sheet of lead.
@@ -1869,7 +1869,7 @@ Source:	Player's Handbook 2024 p. 262</text>
     <range>30 feet</range>
     <components>V, S, M (a yew leaf)</components>
     <duration>Concentration, up to 10 minute</duration>
-    <classes>Cleric [2024], Druid [2024], Ranger [2024], Paladin [2024]</classes>
+    <classes>School: Divination, Cleric [2024], Druid [2024], Ranger [2024], Paladin [2024]</classes>
     <text>For the duration, you sense the location of poisons, poisonous or venomous creatures, and magical contagions within 30 feet of yourself. You sense the kind of poison, creature, or contagion in each case.
 
 The spell is blocked by 1 foot of stone, dirt, or wood; 1 inch of metal; or a thin sheet of lead.
@@ -1884,7 +1884,7 @@ Source:	Player's Handbook 2024 p. 262</text>
     <range>Self</range>
     <components>V, S, M (1 Copper Piece)</components>
     <duration>Concentration, up to 1 minute</duration>
-    <classes>Bard [2024], Sorcerer [2024], Wizard [2024], Sorcerer [2024] (Aberrant), Warlock [2024] (Great Old One)</classes>
+    <classes>School: Divination, Bard [2024], Sorcerer [2024], Wizard [2024], Sorcerer [2024] (Aberrant), Warlock [2024] (Great Old One)</classes>
     <text>You activate one of the effects below. Until the spell ends, you can activate either effect as a Magic action on your later turns.
 
 Sense Thoughts:
@@ -1907,7 +1907,7 @@ Source:	Player's Handbook 2024 p. 262</text>
     <range>500 feet</range>
     <components>V</components>
     <duration>Instantaneous</duration>
-    <classes>Bard [2024], Sorcerer [2024], Warlock [2024], Wizard [2024], Cleric [2024] (Trickery), Paladin [2024] (Vengeance), Ranger [2024] (Fey Wanderer)</classes>
+    <classes>School: Conjuration, Bard [2024], Sorcerer [2024], Warlock [2024], Wizard [2024], Cleric [2024] (Trickery), Paladin [2024] (Vengeance), Ranger [2024] (Fey Wanderer)</classes>
     <text>You teleport to a location within range. You arrive at exactly the spot desired. It can be a place you can see, one you can visualize, or one you can describe by stating distance and direction, such as "200 feet straight downward" or "300 feet upward to the northwest at a 45-degree angle."
 
 You can also teleport one willing creature. The creature must be within 5 feet of you when you teleport, and it teleports to a space within 5 feet of your destination space.
@@ -1925,7 +1925,7 @@ Source:	Player's Handbook 2024 p. 262</text>
     <range>Self</range>
     <components>V, S</components>
     <duration>1 hour</duration>
-    <classes>Bard [2024], Sorcerer [2024], Wizard [2024], Cleric [2024] (Trickery), Ranger [2024] (Gloomstalker)</classes>
+    <classes>School: Illusion, Bard [2024], Sorcerer [2024], Wizard [2024], Cleric [2024] (Trickery), Ranger [2024] (Gloomstalker)</classes>
     <text>You make yourself—including your clothing, armor, weapons, and other belongings on your person—look different until the spell ends. You can seem 1 foot shorter or taller and can appear heavier or lighter. You must adopt a form that has the same basic arrangement of limbs as you have. Otherwise, the extent of the illusion is up to you.
 
 The changes wrought by this spell fail to hold up to physical inspection. For example, if you use this spell to add a hat to your outfit, objects pass through the hat, and anyone who touches it would feel nothing.
@@ -1942,7 +1942,7 @@ Source:	Player's Handbook 2024 p. 262</text>
     <range>60 feet</range>
     <components>V, S, M (a lodestone and dust)</components>
     <duration>Instantaneous</duration>
-    <classes>Sorcerer [2024], Wizard [2024]</classes>
+    <classes>School: Transmutation, Sorcerer [2024], Wizard [2024]</classes>
     <text>You launch a green ray at a target you can see within range. The target can be a creature, a nonmagical object, or a creation of magical force, such as the wall created by Wall of Force.
 
 A creature targeted by this spell makes a Dexterity saving throw. On a failed save, the target takes 10d6 + 40 Force damage. If this damage reduces it to 0 Hit Points, it and everything nonmagical it is wearing and carrying are disintegrated into gray dust. The target can be revived only by a True Resurrection or a Wish spell.
@@ -1966,7 +1966,7 @@ Source:	Player's Handbook 2024 p. 263</text>
     <range>Self</range>
     <components>V, S, M (powdered silver and iron)</components>
     <duration>Concentration, up to 1 minute</duration>
-    <classes>Cleric [2024], Paladin [2024]</classes>
+    <classes>School: Abjuration, Cleric [2024], Paladin [2024]</classes>
     <text>For the duration, Celestials, Elementals, Fey, Fiends, and Undead have Disadvantage on attack rolls against you. You can end the spell early by using either of the following special functions.
 
 Break Enchantment:
@@ -1985,7 +1985,7 @@ Source:	Player's Handbook 2024 p. 263</text>
     <range>120 feet</range>
     <components>V, S</components>
     <duration>Instantaneous</duration>
-    <classes>Bard [2024], Cleric [2024], Druid [2024], Ranger [2024], Sorcerer [2024], Warlock [2024], Wizard [2024], Paladin [2024], Paladin [2024] (Devotion), Sorcerer [2024] (Clockwork)</classes>
+    <classes>School: Abjuration, Bard [2024], Cleric [2024], Druid [2024], Ranger [2024], Sorcerer [2024], Warlock [2024], Wizard [2024], Paladin [2024], Paladin [2024] (Devotion), Sorcerer [2024] (Clockwork)</classes>
     <text>Choose one creature, object, or magical effect within range. Any ongoing spell of level 3 or lower on the target ends. For each ongoing spell of level 4 or higher on the target, make an ability check using your spellcasting ability (DC 10 plus that spell's level). On a successful check, the spell ends.
 
 Using a Higher-Level Spell Slot:
@@ -2001,7 +2001,7 @@ Source:	Player's Handbook 2024 p. 265</text>
     <range>60 feet</range>
     <components>V</components>
     <duration>Instantaneous</duration>
-    <classes>Bard [2024], Sorcerer [2024] (Aberrant), Warlock [2024] (Great Old One)</classes>
+    <classes>School: Enchantment, Bard [2024], Sorcerer [2024] (Aberrant), Warlock [2024] (Great Old One)</classes>
     <text>One creature of your choice that you can see within range hears a discordant melody in its mind. The target makes a Wisdom saving throw. On a failed save, it takes 3d6 Psychic damage and must immediately use its Reaction, if available, to move as far away from you as it can, using the safest route. On a successful save, the target takes half as much damage only.
 
 Using a Higher-Level Spell Slot:
@@ -2027,7 +2027,7 @@ Source:	Player's Handbook 2024 p. 264</text>
     <range>Self</range>
     <components>V, S, M (incense worth 25+ GP, which the spell consumes)</components>
     <duration>Instantaneous</duration>
-    <classes>Cleric [2024], Druid [2024], Wizard [2024]</classes>
+    <classes>School: Divination, Cleric [2024], Druid [2024], Wizard [2024]</classes>
     <text>This spell puts you in contact with a god or a god's servants. You ask one question about a specific goal, event, or activity to occur within 7 days. The DM offers a truthful reply, which might be a short phrase or cryptic rhyme. The spell doesn't account for circumstances that might change the answer, such as the casting of other spells.
 
 If you cast the spell more than once before finishing a Long Rest, there is a cumulative 25 chance for each casting after the first that you get no answer.
@@ -2042,7 +2042,7 @@ Source:	Player's Handbook 2024 p. 264</text>
     <range>Touch</range>
     <components>V, S</components>
     <duration>1 minute</duration>
-    <classes>Paladin [2024]</classes>
+    <classes>School: Transmutation, Paladin [2024]</classes>
     <text>Until the spell ends, your attacks with weapons deal an extra 1d4 Radiant damage on a hit.
 
 Source:	Player's Handbook 2024 p. 265</text>
@@ -2056,7 +2056,7 @@ Source:	Player's Handbook 2024 p. 265</text>
     <range>Self</range>
     <components>V</components>
     <duration>Instantaneous</duration>
-    <classes>Paladin [2024]</classes>
+    <classes>School: Transmutation, Paladin [2024]</classes>
     <text>The target takes an extra 2d8 Radiant damage from the attack. The damage increases by 1d8 if the target is a Fiend or an Undead.
 
 Using a Higher-Level Spell Slot:
@@ -2082,7 +2082,7 @@ Source:	Player's Handbook 2024 p. 265</text>
     <range>30 feet</range>
     <components>V</components>
     <duration>Instantaneous</duration>
-    <classes>Cleric [2024]</classes>
+    <classes>School: Evocation, Cleric [2024]</classes>
     <text>You utter a word imbued with power from the Upper Planes. Each creature of your choice in range makes a Charisma saving throw. On a failed save, a target that has 50 Hit Points or fewer suffers an effect based on its current Hit Points, as shown in the Divine Word Effects table. Regardless of its Hit Points, a Celestial, an Elemental, a Fey, or a Fiend target that fails its save is forced back to its plane of origin (if it isn't there already) and can't return to the current plane for 24 hours by any means short of a Wish spell.
 
 Divine Word Effects:
@@ -2102,7 +2102,7 @@ Source:	Player's Handbook 2024 p. 265</text>
     <range>60 feet</range>
     <components>V, S</components>
     <duration>Concentration, up to 1 minute</duration>
-    <classes>Druid [2024], Ranger [2024], Sorcerer [2024], Warlock [2024] (Archfey)</classes>
+    <classes>School: Enchantment, Druid [2024], Ranger [2024], Sorcerer [2024], Warlock [2024] (Archfey)</classes>
     <text>One Beast you can see within range must succeed on a Wisdom saving throw or have the Charmed condition for the duration. The target has Advantage on the save if you or your allies are fighting it. Whenever the target takes damage, it repeats the save, ending the spell on itself on a success.
 
 You have a telepathic link with the Charmed target while the two of you are on the same plane of existence. On your turn, you can use this link to issue commands to the target (no action required), such as "Attack that creature," "Move over there," or "Fetch that object." The target does its best to obey on its turn. If it completes an order and doesn't receive further direction from you, it acts and moves as it likes, focusing on protecting itself.
@@ -2122,7 +2122,7 @@ Source:	Player's Handbook 2024 p. 265</text>
     <range>60 feet</range>
     <components>V, S</components>
     <duration>Concentration, up to 1 hour</duration>
-    <classes>Bard [2024], Sorcerer [2024], Warlock [2024], Wizard [2024]</classes>
+    <classes>School: Enchantment, Bard [2024], Sorcerer [2024], Warlock [2024], Wizard [2024]</classes>
     <text>One creature you can see within range must succeed on a Wisdom saving throw or have the Charmed condition for the duration. The target has Advantage on the save if you or your allies are fighting it. Whenever the target takes damage, it repeats the save, ending the spell on itself on a success.
 
 You have a telepathic link with the Charmed target while the two of you are on the same plane of existence. On your turn, you can use this link to issue commands to the target (no action required), such as "Attack that creature," "Move over there," or "Fetch that object." The target does its best to obey on its turn. If it completes an order and doesn't receive further direction from you, it acts and moves as it likes, focusing on protecting itself.
@@ -2142,7 +2142,7 @@ Source:	Player's Handbook 2024 p. 265</text>
     <range>60 feet</range>
     <components>V, S</components>
     <duration>Concentration, up to 1 minute</duration>
-    <classes>Bard [2024], Sorcerer [2024], Wizard [2024], Cleric [2024] (Trickery), Warlock [2024] (Archfey)</classes>
+    <classes>School: Enchantment, Bard [2024], Sorcerer [2024], Wizard [2024], Cleric [2024] (Trickery), Warlock [2024] (Archfey)</classes>
     <text>One Humanoid you can see within range must succeed on a Wisdom saving throw or have the Charmed condition for the duration. The target has Advantage on the save if you or your allies are fighting it. Whenever the target takes damage, it repeats the save, ending the spell on itself on a success.
 
 You have a telepathic link with the Charmed target while the two of you are on the same plane of existence. On your turn, you can use this link to issue commands to the target (no action required), such as "Attack that creature," "Move over there," or "Fetch that object." The target does its best to obey on its turn. If it completes an order and doesn't receive further direction from you, it acts and moves as it likes, focusing on protecting itself.
@@ -2162,7 +2162,7 @@ Source:	Player's Handbook 2024 p. 266</text>
     <range>Touch</range>
     <components>V, S, M (a hot pepper)</components>
     <duration>Concentration, up to 1 minute</duration>
-    <classes>Sorcerer [2024], Wizard [2024], Sorcerer [2024] (Draconic)</classes>
+    <classes>School: Transmutation, Sorcerer [2024], Wizard [2024], Sorcerer [2024] (Draconic)</classes>
     <text>You touch one willing creature, and choose Acid, Cold, Fire, Lightning, or Poison. Until the spell ends, the target can take a Magic action to exhale a 15-foot Cone. Each creature in that area makes a Dexterity saving throw, taking 3d6 damage of the chosen type on a failed save or half as much damage on a successful one.
 
 Using a Higher-Level Spell Slot:
@@ -2187,7 +2187,7 @@ Source:	Player's Handbook 2024 p. 266</text>
     <range>Touch</range>
     <components>V, S, M (a sapphire worth 1,000+ GP)</components>
     <duration/>
-    <classes>Wizard [2024]</classes>
+    <classes>School: Conjuration, Wizard [2024]</classes>
     <text>You touch the sapphire used in the casting and an object weighing 10 pounds or less whose longest dimension is 6 feet or less. The spell leaves an Invisible mark on that object and invisibly inscribes the object's name on the sapphire. Each time you cast this spell, you must use a different sapphire.
 
 Thereafter, you can take a Magic action to speak the object's name and crush the sapphire. The object instantly appears in your hand regardless of physical or planar distances, and the spell ends.
@@ -2204,7 +2204,7 @@ Source:	Player's Handbook 2024 p. 266</text>
     <range>Self</range>
     <components>V, S, M (a handful of sand)</components>
     <duration>8 hour</duration>
-    <classes>Bard [2024], Warlock [2024], Wizard [2024]</classes>
+    <classes>School: Illusion, Bard [2024], Warlock [2024], Wizard [2024]</classes>
     <text>You target a creature you know on the same plane of existence. You or a willing creature you touch enters a trance state to act as a dream messenger. While in the trance, the messenger is Incapacitated and has a Speed of 0.
 
 If the target is asleep, the messenger appears in the target's dreams and can converse with the target as long as it remains asleep, through the spell's duration. The messenger can also shape the dream's environment, creating landscapes, objects, and other images. The messenger can emerge from the trance at any time, ending the spell. The target recalls the dream perfectly upon waking.
@@ -2224,7 +2224,7 @@ Source:	Player's Handbook 2024 p. 266</text>
     <range>30 feet</range>
     <components>V, S</components>
     <duration>Instantaneous</duration>
-    <classes>Druid [2024]</classes>
+    <classes>School: Transmutation, Druid [2024]</classes>
     <text>Whispering to the spirits of nature, you create one of the following effects within range.
 
 Weather Sensor:
@@ -2249,7 +2249,7 @@ Source:	Player's Handbook 2024 p. 266</text>
     <range>500 feet</range>
     <components>V, S, M (a fractured rock)</components>
     <duration>Concentration, up to 1 minute</duration>
-    <classes>Cleric [2024], Druid [2024], Sorcerer [2024]</classes>
+    <classes>School: Transmutation, Cleric [2024], Druid [2024], Sorcerer [2024]</classes>
     <text>Choose a point on the ground that you can see within range. For the duration, an intense tremor rips through the ground in a 100-foot-radius circle centered on that point. The ground there is Difficult Terrain.
 
 When you cast this spell and at the end of each of your turns for the duration, each creature on the ground in the area makes a Dexterity saving throw. On a failed save, a creature has the Prone condition, and its Concentration is broken.
@@ -2277,7 +2277,7 @@ Source:	Player's Handbook 2024 p. 267</text>
     <range>120 feet</range>
     <components>V, S</components>
     <duration>Instantaneous</duration>
-    <classes>Warlock [2024]</classes>
+    <classes>School: Evocation, Warlock [2024]</classes>
     <text>You hurl a beam of crackling energy. Make a ranged spell attack against one creature or object in range. On a hit, the target takes 1d10 Force damage.
 
 Cantrip Upgrade: The spell creates two beams at level 5, three beams at level 11, and four beams at level 17. You can direct the beams at the same target or at different ones. Make a separate attack roll for each beam.
@@ -2294,7 +2294,7 @@ Source:	Player's Handbook 2024 p. 267</text>
     <range>Touch</range>
     <components>V, S</components>
     <duration>Concentration, up to 1 hour</duration>
-    <classes>Druid [2024], Ranger [2024], Paladin [2024]</classes>
+    <classes>School: Transmutation, Druid [2024], Ranger [2024], Paladin [2024]</classes>
     <text>A nonmagical weapon you touch becomes a magic weapon. Choose one of the following damage types: Acid, Cold, Fire, Lightning, or Thunder. For the duration, the weapon has a +1 bonus to attack rolls and deals an extra 1d4 damage of the chosen type when it hits.
 
 Using a Higher-Level Spell Slot:
@@ -2311,7 +2311,7 @@ Source:	Player's Handbook 2024 p. 268</text>
     <range>30 feet</range>
     <components>V, S</components>
     <duration>Instantaneous</duration>
-    <classes>Druid [2024], Sorcerer [2024], Wizard [2024]</classes>
+    <classes>School: Transmutation, Druid [2024], Sorcerer [2024], Wizard [2024]</classes>
     <text>You exert control over the elements, creating one of the following effects within range.
 
 Beckon Air:
@@ -2339,7 +2339,7 @@ Source:	Player's Handbook 2024 p. 267</text>
     <range>Touch</range>
     <components>V, S, M (fur or a feather)</components>
     <duration>Concentration, up to 1 hour</duration>
-    <classes>Bard [2024], Cleric [2024], Druid [2024], Ranger [2024], Sorcerer [2024], Wizard [2024], Paladin [2024] (Glory)</classes>
+    <classes>School: Transmutation, Bard [2024], Cleric [2024], Druid [2024], Ranger [2024], Sorcerer [2024], Wizard [2024], Paladin [2024] (Glory)</classes>
     <text>You touch a creature and choose Strength, Dexterity, Intelligence, Wisdom, or Charisma. For the duration, the target has Advantage on ability checks using the chosen ability.
 
 Using a Higher-Level Spell Slot:
@@ -2355,7 +2355,7 @@ Source:	Player's Handbook 2024 p. 268</text>
     <range>30 feet</range>
     <components>V, S, M (a pinch of powdered iron)</components>
     <duration>Concentration, up to 1 minute</duration>
-    <classes>Bard [2024], Druid [2024], Sorcerer [2024], Wizard [2024]</classes>
+    <classes>School: Transmutation, Bard [2024], Druid [2024], Sorcerer [2024], Wizard [2024]</classes>
     <text>For the duration, the spell enlarges or reduces a creature or an object you can see within range (see the chosen effect below). A targeted object must be neither worn nor carried. If the target is an unwilling creature, it can make a Constitution saving throw. On a successful save, the spell has no effect.
 
 Everything that a targeted creature is wearing and carrying changes size with it. Any item it drops returns to normal size at once. A thrown weapon or piece of ammunition returns to normal size immediately after it hits or misses a target.
@@ -2377,7 +2377,7 @@ Source:	Player's Handbook 2024 p. 268</text>
     <range>Self</range>
     <components>V</components>
     <duration>Concentration, up to 1 minute</duration>
-    <classes>Ranger [2024], Paladin [2024] (Ancient)</classes>
+    <classes>School: Conjuration, Ranger [2024], Paladin [2024] (Ancient)</classes>
     <text>As you hit the target, grasping vines appear on it, and it makes a Strength saving throw. A Large or larger creature has Advantage on this save. On a failed save, the target has the Restrained condition until the spell ends. On a successful save, the vines shrivel away, and the spell ends.
 
 While Restrained, the target takes 1d6 Piercing damage at the start of each of its turns. The target or a creature within reach of it can take an action to make a Strength (Athletics) check against your spell save DC. On a success, the spell ends.
@@ -2404,7 +2404,7 @@ Source:	Player's Handbook 2024 p. 268</text>
     <range>90 feet</range>
     <components>V, S</components>
     <duration>Concentration, up to 1 minute</duration>
-    <classes>Druid [2024], Ranger [2024]</classes>
+    <classes>School: Conjuration, Druid [2024], Ranger [2024]</classes>
     <text>Grasping plants sprout from the ground in a 20-foot square within range. For the duration, these plants turn the ground in the area into Difficult Terrain. They disappear when the spell ends.
 
 Each creature (other than you) in the area when you cast the spell must succeed on a Strength saving throw or have the Restrained condition until the spell ends. A Restrained creature can take an action to make a Strength (Athletics) check against your spell save DC. On a success, it frees itself from the grasping plants and is no longer Restrained by them.
@@ -2419,7 +2419,7 @@ Source:	Player's Handbook 2024 p. 268</text>
     <range>60 feet</range>
     <components>V, S</components>
     <duration>1 minute</duration>
-    <classes>Bard [2024], Warlock [2024]</classes>
+    <classes>School: Enchantment, Bard [2024], Warlock [2024]</classes>
     <text>You weave a distracting string of words, causing creatures of your choice that you can see within range to make a Wisdom saving throw. Any creature you or your companions are fighting automatically succeeds on this save. On a failed save, a target has a -10 penalty to Wisdom (Perception) checks and Passive Perception until the spell ends.
 
 Source:	Player's Handbook 2024 p. 269</text>
@@ -2432,7 +2432,7 @@ Source:	Player's Handbook 2024 p. 269</text>
     <range>Self</range>
     <components>V, S</components>
     <duration>8 hour</duration>
-    <classes>Bard [2024], Cleric [2024], Sorcerer [2024], Warlock [2024], Wizard [2024]</classes>
+    <classes>School: Conjuration, Bard [2024], Cleric [2024], Sorcerer [2024], Warlock [2024], Wizard [2024]</classes>
     <text>You step into the border regions of the Ethereal Plane, where it overlaps with your current plane. You remain in the Border Ethereal for the duration. During this time, you can move in any direction. If you move up or down, every foot of movement costs an extra foot. You can perceive the plane you left, which looks gray, and you can't see anything there more than 60 feet away.
 
 While on the Ethereal Plane, you can affect and be affected only by creatures, objects, and effects on that plane. Creatures that aren't on the Ethereal Plane can't perceive or interact with you unless a feature gives them the ability to do so.
@@ -2454,7 +2454,7 @@ Source:	Player's Handbook 2024 p. 269</text>
     <range>90 feet</range>
     <components>V, S, M (a tentacle)</components>
     <duration>Concentration, up to 1 minute</duration>
-    <classes>Wizard [2024], Sorcerer [2024] (Aberrant)</classes>
+    <classes>School: Conjuration, Wizard [2024], Sorcerer [2024] (Aberrant)</classes>
     <text>Squirming, ebony tentacles fill a 20-foot square on ground that you can see within range. For the duration, these tentacles turn the ground in that area into Difficult Terrain.
 
 Each creature in that area makes a Strength saving throw. On a failed save, it takes 3d6 Bludgeoning damage, and it has the Restrained condition until the spell ends. A creature also makes that save if it enters the area or ends it turn there. A creature makes that save only once per turn.
@@ -2472,7 +2472,7 @@ Source:	Player's Handbook 2024 p. 270</text>
     <range>Self</range>
     <components>V, S</components>
     <duration>Concentration, up to 10 minute</duration>
-    <classes>Sorcerer [2024], Warlock [2024], Wizard [2024]</classes>
+    <classes>School: Transmutation, Sorcerer [2024], Warlock [2024], Wizard [2024]</classes>
     <text>You take the Dash action, and until the spell ends, you can take that action again as a Bonus Action.
 
 Source:	Player's Handbook 2024 p. 270</text>
@@ -2485,7 +2485,7 @@ Source:	Player's Handbook 2024 p. 270</text>
     <range>Self</range>
     <components>V, S</components>
     <duration>Concentration, up to 1 minute</duration>
-    <classes>Bard [2024], Sorcerer [2024], Warlock [2024], Wizard [2024]</classes>
+    <classes>School: Necromancy, Bard [2024], Sorcerer [2024], Warlock [2024], Wizard [2024]</classes>
     <text>For the duration, your eyes become an inky void. One creature of your choice within 60 feet of you that you can see must succeed on a Wisdom saving throw or be affected by one of the following effects of your choice for the duration.
 
 On each of your turns until the spell ends, you can take a Magic action to target another creature but can't target a creature again if it has succeeded on a save against this casting of the spell.
@@ -2509,7 +2509,7 @@ Source:	Player's Handbook 2024 p. 270</text>
     <range>120 feet</range>
     <components>V, S</components>
     <duration>Instantaneous</duration>
-    <classes>Wizard [2024]</classes>
+    <classes>School: Transmutation, Wizard [2024]</classes>
     <text>You convert raw materials into products of the same material. For example, you can fabricate a wooden bridge from a clump of trees, a rope from a patch of hemp, or clothes from flax or wool.
 
 Choose raw materials that you can see within range. You can fabricate a Large or smaller object (contained within a 10-foot Cube or eight connected 5-foot Cubes) given a sufficient quantity of material. If you're working with metal, stone, or another mineral substance, however, the fabricated object can be no larger than Medium (contained within a 5-foot Cube). The quality of any fabricated objects is based on the quality of the raw materials.
@@ -2526,7 +2526,7 @@ Source:	Player's Handbook 2024 p. 271</text>
     <range>60 feet</range>
     <components>V</components>
     <duration>Concentration, up to 1 minute</duration>
-    <classes>Bard [2024], Druid [2024], Cleric [2024] (Light), Warlock [2024] (Archfey)</classes>
+    <classes>School: Evocation, Bard [2024], Druid [2024], Cleric [2024] (Light), Warlock [2024] (Archfey)</classes>
     <text>Objects in a 20-foot Cube within range are outlined in blue, green, or violet light (your choice). Each creature in the Cube is also outlined if it fails a Dexterity saving throw. For the duration, objects and affected creatures shed Dim Light in a 10-foot radius and can't benefit from the Invisible condition.
 
 Attack rolls against an affected creature or object have Advantage if the attacker can see it.
@@ -2541,7 +2541,7 @@ Source:	Player's Handbook 2024 p. 271</text>
     <range>Self</range>
     <components>V, S, M (a drop of alcohol)</components>
     <duration>Instantaneous</duration>
-    <classes>Sorcerer [2024], Wizard [2024]</classes>
+    <classes>School: Necromancy, Sorcerer [2024], Wizard [2024]</classes>
     <text>You gain 2d4 + 4 Temporary Hit Points.
 
 Using a Higher-Level Spell Slot:
@@ -2566,7 +2566,7 @@ Source:	Player's Handbook 2024 p. 271</text>
     <range>30 feet</range>
     <components>V, S, M (a white feather)</components>
     <duration>Concentration, up to 1 minute</duration>
-    <classes>Bard [2024], Sorcerer [2024], Warlock [2024], Wizard [2024], Ranger [2024] (Gloomstalker), Sorcerer [2024] (Draconic)</classes>
+    <classes>School: Illusion, Bard [2024], Sorcerer [2024], Warlock [2024], Wizard [2024], Ranger [2024] (Gloomstalker), Sorcerer [2024] (Draconic)</classes>
     <text>Each creature in a 30-foot Cone must succeed on a Wisdom saving throw or drop whatever it is holding and have the Frightened condition for the duration.
 
 A Frightened creature takes the Dash action and moves away from you by the safest route on each of its turns unless there is nowhere to move. If the creature ends its turn in a space where it doesn't have line of sight to you, the creature makes a Wisdom saving throw. On a successful save, the spell ends on that creature.
@@ -2581,7 +2581,7 @@ Source:	Player's Handbook 2024 p. 271</text>
     <range>60 feet</range>
     <components>V, M (a small feather or piece of down)</components>
     <duration>1 minute</duration>
-    <classes>Bard [2024], Sorcerer [2024], Wizard [2024]</classes>
+    <classes>School: Transmutation, Bard [2024], Sorcerer [2024], Wizard [2024]</classes>
     <text>Choose up to five falling creatures within range. A falling creature's rate of descent slows to 60 feet per round until the spell ends. If a creature lands before the spell ends, the creature takes no damage from the fall, and the spell ends for that creature.
 
 Source:	Player's Handbook 2024 p. 271</text>
@@ -2595,7 +2595,7 @@ Source:	Player's Handbook 2024 p. 271</text>
     <range>Touch</range>
     <components>V, S, M (a pinch of graveyard dirt)</components>
     <duration>1 hour</duration>
-    <classes>Bard [2024], Cleric [2024], Druid [2024], Wizard [2024]</classes>
+    <classes>School: Necromancy, Bard [2024], Cleric [2024], Druid [2024], Wizard [2024]</classes>
     <text>You touch a willing creature and put it into a cataleptic state that is indistinguishable from death.
 
 For the duration, the target appears dead to outward inspection and to spells used to determine the target's status. The target has the Blinded and Incapacitated conditions, and its Speed is 0.
@@ -2613,7 +2613,7 @@ Source:	Player's Handbook 2024 p. 271</text>
     <range>10 feet</range>
     <components>V, S, M (burning incense worth 10+ GP, which the spell consumes)</components>
     <duration>Instantaneous</duration>
-    <classes>Wizard [2024]</classes>
+    <classes>School: Conjuration, Wizard [2024]</classes>
     <text>You gain the service of a familiar, a spirit that takes an animal form you choose: Bat, Cat, Frog, Hawk, Lizard, Octopus, Owl, Rat, Raven, Spider, Weasel, or another Beast that has a Challenge Rating of 0. Appearing in an unoccupied space within range, the familiar has the statistics of the chosen form, though it is a Celestial, Fey, or Fiend (your choice) instead of a Beast. Your familiar acts independently of you, but it obeys your commands.
 
 Telepathic Connection:
@@ -2640,7 +2640,7 @@ Source:	Player's Handbook 2024 p. 272</text>
     <range>30 feet</range>
     <components>V, S</components>
     <duration>Instantaneous</duration>
-    <classes>Paladin [2024]</classes>
+    <classes>School: Conjuration, Paladin [2024]</classes>
     <text>You summon an otherworldly being that appears as a loyal steed in an unoccupied space of your choice within range. This creature uses the Otherworldly Steed stat block. If you already have a steed from this spell, the steed is replaced by the new one.
 
 The steed resembles a Large, rideable animal of your choice, such as a horse, a camel, a dire wolf, or an elk. Whenever you cast the spell, choose the steed's creature type—Celestial, Fey, or Fiend—which determines certain traits in the stat block.
@@ -2664,7 +2664,7 @@ Source:	Player's Handbook 2024 p. 272</text>
     <range>Self</range>
     <components>V, S, M (a set of divination tools—such as cards or runes—worth 100+ GP)</components>
     <duration>Concentration, up to 1 day</duration>
-    <classes>Bard [2024], Cleric [2024], Druid [2024]</classes>
+    <classes>School: Divination, Bard [2024], Cleric [2024], Druid [2024]</classes>
     <text>You magically sense the most direct physical route to a location you name. You must be familiar with the location, and the spell fails if you name a destination on another plane of existence, a moving destination (such as a mobile fortress), or an unspecific destination (such as "a green dragon's lair").
 
 For the duration, as long as you are on the same plane of existence as the destination, you know how far it is and in what direction it lies. Whenever you face a choice of paths along the way there, you know which path is the most direct.
@@ -2679,7 +2679,7 @@ Source:	Player's Handbook 2024 p. 273</text>
     <range>120 feet</range>
     <components>V, S</components>
     <duration>Instantaneous</duration>
-    <classes>Cleric [2024], Druid [2024], Ranger [2024]</classes>
+    <classes>School: Divination, Cleric [2024], Druid [2024], Ranger [2024]</classes>
     <text>You sense any trap within range that is within line of sight. A trap, for the purpose of this spell, includes any object or mechanism that was created to cause damage or other danger. Thus, the spell would sense the Alarm or Glyph of Warding spell or a mechanical pit trap, but it wouldn't reveal a natural weakness in the floor, an unstable ceiling, or a hidden sinkhole.
 
 This spell reveals that a trap is present but not its location. You do learn the general nature of the danger posed by a trap you sense.
@@ -2694,7 +2694,7 @@ Source:	Player's Handbook 2024 p. 273</text>
     <range>60 feet</range>
     <components>V, S</components>
     <duration>Instantaneous</duration>
-    <classes>Sorcerer [2024], Warlock [2024], Wizard [2024]</classes>
+    <classes>School: Necromancy, Sorcerer [2024], Warlock [2024], Wizard [2024]</classes>
     <text>You unleash negative energy toward a creature you can see within range. The target makes a Constitution saving throw, taking 7d8 + 30 Necrotic damage on a failed save or half as much damage on a successful one.
 
 A Humanoid killed by this spell rises at the start of your next turn as a Zombie that follows your verbal orders.
@@ -2710,7 +2710,7 @@ Source:	Player's Handbook 2024 p. 273</text>
     <range>120 feet</range>
     <components>V, S</components>
     <duration>Instantaneous</duration>
-    <classes>Sorcerer [2024], Wizard [2024], Druid [2024] (Arid Land)</classes>
+    <classes>School: Evocation, Sorcerer [2024], Wizard [2024], Druid [2024] (Arid Land)</classes>
     <text>You hurl a mote of fire at a creature or an object within range. Make a ranged spell attack against the target. On a hit, the target takes 1d10 Fire damage. A flammable object hit by this spell starts burning if it isn't being worn or carried.
 
 Cantrip Upgrade: The damage increases by 1d10 when you reach levels 5 (2d10), 11 (3d10), and 17 (4d10).
@@ -2729,7 +2729,7 @@ Source:	Player's Handbook 2024 p. 274</text>
     <range>Self</range>
     <components>V, S, M (a bit of phosphorus or a firefly)</components>
     <duration>10 minute</duration>
-    <classes>Druid [2024], Sorcerer [2024], Wizard [2024], Cleric [2024] (War), Warlock [2024] (Fiend)</classes>
+    <classes>School: Evocation, Druid [2024], Sorcerer [2024], Wizard [2024], Cleric [2024] (War), Warlock [2024] (Fiend)</classes>
     <text>Wispy flames wreathe your body for the duration, shedding Bright Light in a 10-foot radius and Dim Light for an additional 10 feet.
 
 The flames provide you with a warm shield or a chill shield, as you choose. The warm shield grants you Resistance to Cold damage, and the chill shield grants you Resistance to Fire damage.
@@ -2747,7 +2747,7 @@ Source:	Player's Handbook 2024 p. 274</text>
     <range>150 feet</range>
     <components>V, S</components>
     <duration>Instantaneous</duration>
-    <classes>Cleric [2024], Druid [2024], Sorcerer [2024]</classes>
+    <classes>School: Evocation, Cleric [2024], Druid [2024], Sorcerer [2024]</classes>
     <text>A storm of fire appears within range. The area of the storm consists of up to ten 10-foot Cubes, which you arrange as you like. Each Cube must be contiguous with at least one other Cube. Each creature in the area makes a Dexterity saving throw, taking 7d10 Fire damage on a failed save or half as much damage on a successful one.
 
 Flammable objects in the area that aren't being worn or carried start burning.
@@ -2763,7 +2763,7 @@ Source:	Player's Handbook 2024 p. 275</text>
     <range>150 feet</range>
     <components>V, S, M (a ball of bat guano and sulfur)</components>
     <duration>Instantaneous</duration>
-    <classes>Sorcerer [2024], Wizard [2024], Cleric [2024] (Light), Druid [2024] (Arid Land), Warlock [2024] (Fiend)</classes>
+    <classes>School: Evocation, Sorcerer [2024], Wizard [2024], Cleric [2024] (Light), Druid [2024] (Arid Land), Warlock [2024] (Fiend)</classes>
     <text>A bright streak flashes from you to a point you choose within range and then blossoms with a low roar into a fiery explosion. Each creature in a 20-foot-radius Sphere centered on that point makes a Dexterity saving throw, taking 8d6 Fire damage on a failed save or half as much damage on a successful one.
 
 Flammable objects in the area that aren't being worn or carried start burning.
@@ -2788,7 +2788,7 @@ Source:	Player's Handbook 2024 p. 274</text>
     <range>Self</range>
     <components>V, S, M (a sumac leaf)</components>
     <duration>Concentration, up to 10 minute</duration>
-    <classes>Druid [2024], Sorcerer [2024]</classes>
+    <classes>School: Evocation, Druid [2024], Sorcerer [2024]</classes>
     <text>You evoke a fiery blade in your free hand. The blade is similar in size and shape to a scimitar, and it lasts for the duration. If you let go of the blade, it disappears, but you can evoke it again as a Bonus Action.
 
 As a Magic action, you can make a melee spell attack with the fiery blade. On a hit, the target takes Fire damage equal to 3d6 plus your spellcasting ability modifier.
@@ -2816,7 +2816,7 @@ Source:	Player's Handbook 2024 p. 275</text>
     <range>60 feet</range>
     <components>V, S, M (a pinch of sulfur)</components>
     <duration>Instantaneous</duration>
-    <classes>Cleric [2024], Cleric [2024] (Light), Paladin [2024] (Devotion)</classes>
+    <classes>School: Evocation, Cleric [2024], Cleric [2024] (Light), Paladin [2024] (Devotion)</classes>
     <text>A vertical column of brilliant fire roars down from above. Each creature in a 10-foot-radius, 40-foot-high Cylinder centered on a point within range makes a Dexterity saving throw, taking 5d6 Fire damage and 5d6 Radiant damage on a failed save or half as much damage on a successful one.
 
 Using a Higher-Level Spell Slot:
@@ -2842,7 +2842,7 @@ Source:	Player's Handbook 2024 p. 275</text>
     <range>60 feet</range>
     <components>V, S, M (a ball of wax)</components>
     <duration>Concentration, up to 1 minute</duration>
-    <classes>Druid [2024], Sorcerer [2024], Wizard [2024]</classes>
+    <classes>School: Conjuration, Druid [2024], Sorcerer [2024], Wizard [2024]</classes>
     <text>You create a 5-foot-diameter sphere of fire in an unoccupied space on the ground within range. It lasts for the duration. Any creature that ends its turn within 5 feet of the sphere makes a Dexterity saving throw, taking 2d6 Fire damage on a failed save or half as much damage on a successful one.
 
 As a Bonus Action, you can move the sphere up to 30 feet, rolling it along the ground. If you move the sphere into a creature's space, that creature makes the save against the sphere, and the sphere stops moving for the turn.
@@ -2870,7 +2870,7 @@ Source:	Player's Handbook 2024 p. 275</text>
     <range>60 feet</range>
     <components>V, S, M (a cockatrice feather)</components>
     <duration>Concentration, up to 1 minute</duration>
-    <classes>Druid [2024], Sorcerer [2024], Wizard [2024]</classes>
+    <classes>School: Transmutation, Druid [2024], Sorcerer [2024], Wizard [2024]</classes>
     <text>You attempt to turn one creature that you can see within range into stone. The target makes a Constitution saving throw. On a failed save, it has the Restrained condition for the duration. On a successful save, its Speed is 0 until the start of your next turn. Constructs automatically succeed on the save.
 
 A Restrained target makes another Constitution saving throw at the end of each of its turns. If it successfully saves against this spell three times, the spell ends. If it fails its saves three times, it is turned to stone and has the Petrified condition for the duration. The successes and failures needn't be consecutive; keep track of both until the target collects three of a kind.
@@ -2887,7 +2887,7 @@ Source:	Player's Handbook 2024 p. 275</text>
     <range>Touch</range>
     <components>V, S, M (a feather)</components>
     <duration>Concentration, up to 10 minute</duration>
-    <classes>Sorcerer [2024], Warlock [2024], Wizard [2024], Sorcerer [2024] (Draconic)</classes>
+    <classes>School: Transmutation, Sorcerer [2024], Warlock [2024], Wizard [2024], Sorcerer [2024] (Draconic)</classes>
     <text>You touch a willing creature. For the duration, the target gains a Fly Speed of 60 feet and can hover. When the spell ends, the target falls if it is still aloft unless it can stop the fall.
 
 Using a Higher-Level Spell Slot:
@@ -2903,7 +2903,7 @@ Source:	Player's Handbook 2024 p. 276</text>
     <range>120 feet</range>
     <components>V, S</components>
     <duration>Concentration, up to 1 hour</duration>
-    <classes>Druid [2024], Ranger [2024], Sorcerer [2024], Wizard [2024], Druid [2024] (Polar Land), Druid [2024] (Sea)</classes>
+    <classes>School: Conjuration, Druid [2024], Ranger [2024], Sorcerer [2024], Wizard [2024], Druid [2024] (Polar Land), Druid [2024] (Sea)</classes>
     <text>You create a 20-foot-radius Sphere of fog centered on a point within range. The Sphere is Heavily Obscured. It lasts for the duration or until a strong wind (such as one created by Gust of Wind) disperses it.
 
 Using a Higher-Level Spell Slot:
@@ -2920,7 +2920,7 @@ Source:	Player's Handbook 2024 p. 276</text>
     <range>Touch</range>
     <components>V, S, M (ruby dust worth 1,000+ GP)</components>
     <duration>1 day</duration>
-    <classes>Cleric [2024]</classes>
+    <classes>School: Abjuration, Cleric [2024]</classes>
     <text>You create a ward against magical travel that protects up to 40,000 square feet of floor space to a height of 30 feet above the floor. For the duration, creatures can't teleport into the area or use portals, such as those created by the Gate spell, to enter the area. The spell proofs the area against planar travel, and therefore prevents creatures from accessing the area by way of the Astral Plane, the Ethereal Plane, the Feywild, the Shadowfell, or the Plane Shift spell.
 
 In addition, the spell damages types of creatures that you choose when you cast it. Choose one or more of the following: Aberrations, Celestials, Elementals, Fey, Fiends, and Undead. When a creature of a chosen type enters the spell's area for the first time on a turn or ends its turn there, the creature takes 5d10 Radiant or Necrotic damage (your choice when you cast this spell).
@@ -2940,7 +2940,7 @@ Source:	Player's Handbook 2024 p. 276</text>
     <range>100 feet</range>
     <components>V, S, M (ruby dust worth 1,500+ GP, which the spell consumes)</components>
     <duration>Concentration, up to 1 hour</duration>
-    <classes>Bard [2024], Warlock [2024], Wizard [2024]</classes>
+    <classes>School: Evocation, Bard [2024], Warlock [2024], Wizard [2024]</classes>
     <text>An immobile, Invisible, Cube-shaped prison composed of magical force springs into existence around an area you choose within range. The prison can be a cage or a solid box, as you choose.
 
 A prison in the shape of a cage can be up to 20 feet on a side and is made from 1/2-inch diameter bars spaced 1/2 inch apart. A prison in the shape of a box can be up to 10 feet on a side, creating a solid barrier that prevents any matter from passing through it and blocking any spells cast into or out from the area.
@@ -2961,7 +2961,7 @@ Source:	Player's Handbook 2024 p. 276</text>
     <range>Touch</range>
     <components>V, S, M (a hummingbird feather)</components>
     <duration>8 hour</duration>
-    <classes>Bard [2024], Druid [2024], Warlock [2024], Wizard [2024]</classes>
+    <classes>School: Divination, Bard [2024], Druid [2024], Warlock [2024], Wizard [2024]</classes>
     <text>You touch a willing creature and bestow a limited ability to see into the immediate future. For the duration, the target has Advantage on D20 Tests, and other creatures have Disadvantage on attack rolls against it. The spell ends early if you cast it again.
 
 Source:	Player's Handbook 2024 p. 276</text>
@@ -2974,7 +2974,7 @@ Source:	Player's Handbook 2024 p. 276</text>
     <range>Self</range>
     <components>V, S</components>
     <duration>Concentration, up to 10 minute</duration>
-    <classes>Bard [2024], Druid [2024], Druid [2024] (Moon)</classes>
+    <classes>School: Evocation, Bard [2024], Druid [2024], Druid [2024] (Moon)</classes>
     <text>A cool light wreathes your body for the duration, emitting Bright Light in a 20-foot radius and Dim Light for an additional 20 feet.
 
 Until the spell ends, you have Resistance to Radiant damage, and your melee attacks deal an extra 2d6 Radiant damage on a hit.
@@ -2992,7 +2992,7 @@ Source:	Player's Handbook 2024 p. 277</text>
     <range>Touch</range>
     <components>V, S, M (a leather strap)</components>
     <duration>1 hour</duration>
-    <classes>Bard [2024], Cleric [2024], Druid [2024], Ranger [2024], Cleric [2024] (War), Druid [2024] (Temperate Land), Paladin [2024] (Devotion), Paladin [2024] (Glory), Sorcerer [2024] (Clockwork)</classes>
+    <classes>School: Abjuration, Bard [2024], Cleric [2024], Druid [2024], Ranger [2024], Cleric [2024] (War), Druid [2024] (Temperate Land), Paladin [2024] (Devotion), Paladin [2024] (Glory), Sorcerer [2024] (Clockwork)</classes>
     <text>You touch a willing creature. For the duration, the target's movement is unaffected by Difficult Terrain, and spells and other magical effects can neither reduce the target's Speed nor cause the target to have the Paralyzed or Restrained conditions. The target also has a Swim Speed equal to its Speed.
 
 In addition, the target can spend 5 feet of movement to automatically escape from nonmagical restraints, such as manacles or a creature imposing the Grappled condition on it.
@@ -3010,7 +3010,7 @@ Source:	Player's Handbook 2024 p. 277</text>
     <range>10 feet</range>
     <components>S, M (some makeup)</components>
     <duration>Concentration, up to 1 minute</duration>
-    <classes>Bard [2024], Sorcerer [2024], Warlock [2024], Wizard [2024]</classes>
+    <classes>School: Enchantment, Bard [2024], Sorcerer [2024], Warlock [2024], Wizard [2024]</classes>
     <text>You magically emanate a sense of friendship toward one creature you can see within range. The target must succeed on a Wisdom saving throw or have the Charmed condition for the duration. The target succeeds automatically if it isn't a Humanoid, if you're fighting it, or if you have cast this spell on it within the past 24 hours.
 
 The spell ends early if the target takes damage or if you make an attack roll, deal damage, or force anyone to make a saving throw. When the spell ends, the target knows it was Charmed by you.
@@ -3025,7 +3025,7 @@ Source:	Player's Handbook 2024 p. 277</text>
     <range>Touch</range>
     <components>V, S, M (a bit of gauze)</components>
     <duration>Concentration, up to 1 hour</duration>
-    <classes>Sorcerer [2024], Warlock [2024], Wizard [2024]</classes>
+    <classes>School: Transmutation, Sorcerer [2024], Warlock [2024], Wizard [2024]</classes>
     <text>A willing creature you touch shape-shifts, along with everything it's wearing and carrying, into a misty cloud for the duration. The spell ends on the target if it drops to 0 Hit Points or if it takes a Magic action to end the spell on itself.
 
 While in this form, the target's only method of movement is a Fly Speed of 10 feet, and it can hover. The target can enter and occupy the space of another creature. The target has Resistance to Bludgeoning, Piercing, and Slashing damage; it has Immunity to the Prone condition; and it has Advantage on Strength, Dexterity, and Constitution saving throws. The target can pass through narrow openings, but it treats liquids as though they were solid surfaces.
@@ -3045,7 +3045,7 @@ Source:	Player's Handbook 2024 p. 277</text>
     <range>60 feet</range>
     <components>V, S, M (a diamond worth 5,000+ GP)</components>
     <duration>Concentration, up to 1 minute</duration>
-    <classes>Cleric [2024], Sorcerer [2024], Warlock [2024], Wizard [2024]</classes>
+    <classes>School: Conjuration, Cleric [2024], Sorcerer [2024], Warlock [2024], Wizard [2024]</classes>
     <text>You conjure a portal linking an unoccupied space you can see within range to a precise location on a different plane of existence. The portal is a circular opening, which you can make 5 to 20 feet in diameter. You can orient the portal in any direction you choose. The portal lasts for the duration, and the portal's destination is visible through it.
 
 The portal has a front and a back on each plane where it appears. Travel through the portal is possible only by moving through its front. Anything that does so is instantly transported to the other plane, appearing in the unoccupied space nearest to the portal.
@@ -3064,7 +3064,7 @@ Source:	Player's Handbook 2024 p. 277</text>
     <range>60 feet</range>
     <components>V</components>
     <duration>30 day</duration>
-    <classes>Bard [2024], Cleric [2024], Druid [2024], Wizard [2024], Paladin [2024], Warlock [2024] (Fiend)</classes>
+    <classes>School: Enchantment, Bard [2024], Cleric [2024], Druid [2024], Wizard [2024], Paladin [2024], Warlock [2024] (Fiend)</classes>
     <text>You give a verbal command to a creature that you can see within range, ordering it to carry out some service or refrain from an action or a course of activity as you decide. The target must succeed on a Wisdom saving throw or have the Charmed condition for the duration. The target automatically succeeds if it can't understand your command.
 
 While Charmed, the creature takes 5d10 Psychic damage if it acts in a manner directly counter to your command. It takes this damage no more than once each day.
@@ -3088,7 +3088,7 @@ Source:	Player's Handbook 2024 p. 278</text>
     <range>Touch</range>
     <components>V, S, M (2 Copper Pieces, which the spell consumes)</components>
     <duration>10 day</duration>
-    <classes>Cleric [2024], Wizard [2024], Paladin [2024]</classes>
+    <classes>School: Necromancy, Cleric [2024], Wizard [2024], Paladin [2024]</classes>
     <text>You touch a corpse or other remains. For the duration, the target is protected from decay and can't become Undead.
 
 The spell also effectively extends the time limit on raising the target from the dead, since days spent under the influence of this spell don't count against the time limit of spells such as Raise Dead.
@@ -3103,7 +3103,7 @@ Source:	Player's Handbook 2024 p. 278</text>
     <range>60 feet</range>
     <components>V, S</components>
     <duration>Concentration, up to 10 minute</duration>
-    <classes>Druid [2024]</classes>
+    <classes>School: Conjuration, Druid [2024]</classes>
     <text>You summon a giant centipede, spider, or wasp (chosen when you cast the spell). It manifests in an unoccupied space you can see within range and uses the Giant Insect stat block. The form you choose determines certain details in its stat block. The creature disappears when it drops to 0 Hit Points or when the spell ends.
 
 The creature is an ally to you and your allies. In combat, the creature shares your Initiative count, but it takes its turn immediately after yours. It obeys your verbal commands (no action required by you). If you don't issue any, it takes the Dodge action and uses its movement to avoid danger.
@@ -3121,7 +3121,7 @@ Source:	Player's Handbook 2024 p. 279</text>
     <range>Self</range>
     <components>V</components>
     <duration>1 hour</duration>
-    <classes>Bard [2024], Warlock [2024]</classes>
+    <classes>School: Transmutation, Bard [2024], Warlock [2024]</classes>
     <text>Until the spell ends, when you make a Charisma check, you can replace the number you roll with a 15. Additionally, no matter what you say, magic that would determine if you are telling the truth indicates that you are being truthful.
 
 Source:	Player's Handbook 2024 p. 279</text>
@@ -3134,7 +3134,7 @@ Source:	Player's Handbook 2024 p. 279</text>
     <range>Self</range>
     <components>V, S, M (a glass bead)</components>
     <duration>Concentration, up to 1 minute</duration>
-    <classes>Sorcerer [2024], Wizard [2024]</classes>
+    <classes>School: Abjuration, Sorcerer [2024], Wizard [2024]</classes>
     <text>An immobile, shimmering barrier appears in a 10-foot Emanation around you and remains for the duration.
 
 Any spell of level 5 or lower cast from outside the barrier can't affect anything within it. Such a spell can target creatures and objects within the barrier, but the spell has no effect on them. Similarly, the area within the barrier is excluded from areas of effect created by such spells.
@@ -3152,7 +3152,7 @@ Source:	Player's Handbook 2024 p. 279</text>
     <range>Touch</range>
     <components>V, S, M (powdered diamond worth 200+ GP, which the spell consumes)</components>
     <duration/>
-    <classes>Bard [2024], Cleric [2024], Wizard [2024]</classes>
+    <classes>School: Abjuration, Bard [2024], Cleric [2024], Wizard [2024]</classes>
     <text>You inscribe a glyph that later unleashes a magical effect. You inscribe it either on a surface (such as a table or a section of floor) or within an object that can be closed (such as a book or chest) to conceal the glyph. The glyph can cover an area no larger than 10 feet in diameter. If the surface or object is moved more than 10 feet from where you cast this spell, the glyph is broken, and the spell ends without being triggered.
 
 The glyph is nearly imperceptible and requires a successful Wisdom (Perception) check against your spell save DC to notice.
@@ -3192,7 +3192,7 @@ Source:	Player's Handbook 2024 p. 279</text>
     <range>Touch</range>
     <components>V, S, M (a sprig of mistletoe)</components>
     <duration>24 hour</duration>
-    <classes>Druid [2024], Ranger [2024]</classes>
+    <classes>School: Conjuration, Druid [2024], Ranger [2024]</classes>
     <text>Ten berries appear in your hand and are infused with magic for the duration. A creature can take a Bonus Action to eat one berry. Eating a berry restores 1 Hit Point, and the berry provides enough nourishment to sustain a creature for one day.
 
 Uneaten berries disappear when the spell ends.
@@ -3207,7 +3207,7 @@ Source:	Player's Handbook 2024 p. 280</text>
     <range>60 feet</range>
     <components>V, S</components>
     <duration>Concentration, up to 1 minute</duration>
-    <classes>Druid [2024], Ranger [2024]</classes>
+    <classes>School: Conjuration, Druid [2024], Ranger [2024]</classes>
     <text>You conjure a vine that sprouts from a surface in an unoccupied space that you can see within range. The vine lasts for the duration.
 
 Make a melee spell attack against a creature within 30 feet of the vine. On a hit, the target takes 4d8 Bludgeoning damage and is pulled up to 30 feet toward the vine; if the target is Huge or smaller, it has the Grappled condition (escape DC equal to your spell save DC). The vine can grapple only one creature at a time, and you can cause the vine to release a Grappled creature (no action required).
@@ -3228,7 +3228,7 @@ Source:	Player's Handbook 2024 p. 280</text>
     <range>60 feet</range>
     <components>V, S, M (a bit of pork rind or butter)</components>
     <duration>1 minute</duration>
-    <classes>Sorcerer [2024], Wizard [2024]</classes>
+    <classes>School: Conjuration, Sorcerer [2024], Wizard [2024]</classes>
     <text>Nonflammable grease covers the ground in a 10-foot square centered on a point within range and turns it into Difficult Terrain for the duration.
 
 When the grease appears, each creature standing in its area must succeed on a Dexterity saving throw or have the Prone condition. A creature that enters the area or ends its turn there must also succeed on that save or fall Prone.
@@ -3243,7 +3243,7 @@ Source:	Player's Handbook 2024 p. 280</text>
     <range>Touch</range>
     <components>V, S</components>
     <duration>Concentration, up to 1 minute</duration>
-    <classes>Bard [2024], Sorcerer [2024], Wizard [2024], Ranger [2024] (Gloomstalker), Warlock [2024] (Archfey)</classes>
+    <classes>School: Illusion, Bard [2024], Sorcerer [2024], Wizard [2024], Ranger [2024] (Gloomstalker), Warlock [2024] (Archfey)</classes>
     <text>A creature you touch has the Invisible condition until the spell ends.
 
 Invisible:
@@ -3260,7 +3260,7 @@ Source:	Player's Handbook 2024 p. 281</text>
     <range>Touch</range>
     <components>V, S, M (diamond dust worth 100+ GP, which the spell consumes)</components>
     <duration>Instantaneous</duration>
-    <classes>Bard [2024], Cleric [2024], Druid [2024], Ranger [2024], Paladin [2024], Cleric [2024] (Life), Sorcerer [2024] (Clockwork), Warlock [2024] (Celestial)</classes>
+    <classes>School: Abjuration, Bard [2024], Cleric [2024], Druid [2024], Ranger [2024], Paladin [2024], Cleric [2024] (Life), Sorcerer [2024] (Clockwork), Warlock [2024] (Celestial)</classes>
     <text>You touch a creature and magically remove one of the following effects from it:
 
 	• 1 Exhaustion level
@@ -3279,7 +3279,7 @@ Source:	Player's Handbook 2024 p. 281</text>
     <range>30 feet</range>
     <components>V</components>
     <duration>8 hour</duration>
-    <classes>Cleric [2024], Paladin [2024] (Devotion), Warlock [2024] (Celestial)</classes>
+    <classes>School: Conjuration, Cleric [2024], Paladin [2024] (Devotion), Warlock [2024] (Celestial)</classes>
     <text>A Large spectral guardian appears and hovers for the duration in an unoccupied space that you can see within range. The guardian occupies that space and is invulnerable, and it appears in a form appropriate for your deity or pantheon.
 
 Any enemy that moves to a space within 10 feet of the guardian for the first time on a turn or starts its turn there makes a Dexterity saving throw, taking 20 Radiant damage on a failed save or half as much damage on a successful one. The guardian vanishes when it has dealt a total of 60 damage.
@@ -3294,7 +3294,7 @@ Source:	Player's Handbook 2024 p. 281</text>
     <range>Touch</range>
     <components>V, S, M (a silver rod worth 10+ GP)</components>
     <duration>24 hour</duration>
-    <classes>Bard [2024], Wizard [2024]</classes>
+    <classes>School: Abjuration, Bard [2024], Wizard [2024]</classes>
     <text>You create a ward that protects up to 2,500 square feet of floor space. The warded area can be up to 20 feet tall, and you shape it as one 50-foot square, one hundred 5-foot squares that are contiguous, or twenty-five 10-foot squares that are contiguous.
 
 When you cast this spell, you can specify individuals that are unaffected by the spell's effects. You can also specify a password that, when spoken aloud within 5 feet of the warded area, makes the speaker immune to its effects.
@@ -3333,7 +3333,7 @@ Source:	Player's Handbook 2024 p. 282</text>
     <range>Touch</range>
     <components>V, S</components>
     <duration>Concentration, up to 1 minute</duration>
-    <classes>Cleric [2024], Druid [2024]</classes>
+    <classes>School: Divination, Cleric [2024], Druid [2024]</classes>
     <text>You touch a willing creature and choose a skill. Until the spell ends, the creature adds 1d4 to any ability check using the chosen skill.
 
 Source:	Player's Handbook 2024 p. 282</text>
@@ -3347,7 +3347,7 @@ Source:	Player's Handbook 2024 p. 282</text>
     <range>120 feet</range>
     <components>V, S</components>
     <duration>1 round</duration>
-    <classes>Cleric [2024], Cleric [2024] (War), Paladin [2024] (Glory), Warlock [2024] (Celestial)</classes>
+    <classes>School: Evocation, Cleric [2024], Cleric [2024] (War), Paladin [2024] (Glory), Warlock [2024] (Celestial)</classes>
     <text>You hurl a bolt of light toward a creature within range. Make a ranged spell attack against the target. On a hit, it takes 4d6 Radiant damage, and the next attack roll made against it before the end of your next turn has Advantage.
 
 Using a Higher-Level Spell Slot:
@@ -3372,7 +3372,7 @@ Source:	Player's Handbook 2024 p. 282</text>
     <range>Self</range>
     <components>V, S, M (a legume seed)</components>
     <duration>Concentration, up to 1 minute</duration>
-    <classes>Druid [2024], Ranger [2024], Sorcerer [2024], Wizard [2024], Druid [2024] (Sea)</classes>
+    <classes>School: Evocation, Druid [2024], Ranger [2024], Sorcerer [2024], Wizard [2024], Druid [2024] (Sea)</classes>
     <text>A Line of strong wind 60 feet long and 10 feet wide blasts from you in a direction you choose for the duration. Each creature in the Line must succeed on a Strength saving throw or be pushed 15 feet away from you in a direction following the Line. A creature that ends its turn in the Line must make the same save.
 
 Any creature in the Line must spend 2 feet of movement for every 1 foot it moves when moving closer to you.
@@ -3391,7 +3391,7 @@ Source:	Player's Handbook 2024 p. 282</text>
     <range>Self</range>
     <components>V</components>
     <duration>Instantaneous</duration>
-    <classes>Ranger [2024]</classes>
+    <classes>School: Conjuration, Ranger [2024]</classes>
     <text>As you hit the creature, this spell creates a rain of thorns that sprouts from your Ranged weapon or ammunition. The target of the attack and each creature within 5 feet of it make a Dexterity saving throw, taking 1d10 Piercing damage on a failed save or half as much damage on a successful one.
 
 Using a Higher-Level Spell Slot:
@@ -3416,7 +3416,7 @@ Source:	Player's Handbook 2024 p. 283</text>
     <range>Touch</range>
     <components>V, S, M (incense worth 1,000+ GP, which the spell consumes)</components>
     <duration/>
-    <classes>Cleric [2024]</classes>
+    <classes>School: Abjuration, Cleric [2024]</classes>
     <text>You touch a point and infuse an area around it with holy or unholy power. The area can have a radius up to 60 feet, and the spell fails if the radius includes an area already under the effect of Hallow. The affected area has the following effects.
 
 Hallowed Ward:
@@ -3465,7 +3465,7 @@ Source:	Player's Handbook 2024 p. 283</text>
     <range>300 feet</range>
     <components>V, S, M (a mushroom)</components>
     <duration>24 hour</duration>
-    <classes>Bard [2024], Druid [2024], Warlock [2024], Wizard [2024]</classes>
+    <classes>School: Illusion, Bard [2024], Druid [2024], Warlock [2024], Wizard [2024]</classes>
     <text>You make natural terrain in a 150-foot Cube in range look, sound, and smell like another sort of natural terrain. Thus, open fields or a road can be made to resemble a swamp, hill, crevasse, or some other difficult or impassable terrain. A pond can be made to seem like a grassy meadow, a precipice like a gentle slope, or a rock-strewn gully like a wide and smooth road. Manufactured structures, equipment, and creatures within the area aren't changed.
 
 The tactile characteristics of the terrain are unchanged, so creatures entering the area are likely to notice the illusion. If the difference isn't obvious by touch, a creature examining the illusion can take the Study action to make an Intelligence (Investigation) check against your spell save DC to disbelieve it. If a creature discerns that the terrain is illusory, the creature sees a vague image superimposed on the real terrain.
@@ -3480,7 +3480,7 @@ Source:	Player's Handbook 2024 p. 283</text>
     <range>60 feet</range>
     <components>V, S</components>
     <duration>Instantaneous</duration>
-    <classes>Cleric [2024]</classes>
+    <classes>School: Necromancy, Cleric [2024]</classes>
     <text>You unleash virulent magic on a creature you can see within range. The target makes a Constitution saving throw. On a failed save, it takes 14d6 Necrotic damage, and its Hit Points maximum is reduced by an amount equal to the Necrotic damage it took. On a successful save, it takes half as much damage only. This spell can't reduce a target's Hit Points maximum below 1.
 
 Source:	Player's Handbook 2024 p. 283</text>
@@ -3494,7 +3494,7 @@ Source:	Player's Handbook 2024 p. 283</text>
     <range>30 feet</range>
     <components>V, S, M (a shaving of licorice root)</components>
     <duration>Concentration, up to 1 minute</duration>
-    <classes>Sorcerer [2024], Wizard [2024], Paladin [2024] (Glory), Paladin [2024] (Vengeance)</classes>
+    <classes>School: Transmutation, Sorcerer [2024], Wizard [2024], Paladin [2024] (Glory), Paladin [2024] (Vengeance)</classes>
     <text>Choose a willing creature that you can see within range. Until the spell ends, the target's Speed is doubled, it gains a +2 bonus to Armor Class, it has Advantage on Dexterity saving throws, and it gains an additional action on each of its turns. That action can be used to take only the Attack (one attack only), Dash, Disengage, Hide, or Utilize action.
 
 When the spell ends, the target is Incapacitated and has a Speed of 0 until the end of its next turn, as a wave of lethargy washes over it.
@@ -3509,7 +3509,7 @@ Source:	Player's Handbook 2024 p. 284</text>
     <range>60 feet</range>
     <components>V, S</components>
     <duration>Instantaneous</duration>
-    <classes>Cleric [2024], Druid [2024]</classes>
+    <classes>School: Abjuration, Cleric [2024], Druid [2024]</classes>
     <text>Choose a creature that you can see within range. Positive energy washes through the target, restoring 70 Hit Points. This spell also ends the Blinded, Deafened, and Poisoned conditions on the target.
 
 Using a Higher-Level Spell Slot:
@@ -3525,7 +3525,7 @@ Source:	Player's Handbook 2024 p. 284</text>
     <range>60 feet</range>
     <components>V</components>
     <duration>Instantaneous</duration>
-    <classes>Bard [2024], Cleric [2024], Druid [2024]</classes>
+    <classes>School: Abjuration, Bard [2024], Cleric [2024], Druid [2024]</classes>
     <text>A creature of your choice that you can see within range regains Hit Points equal to 2d4 plus your spellcasting ability modifier.
 
 Using a Higher-Level Spell Slot:
@@ -3550,7 +3550,7 @@ Source:	Player's Handbook 2024 p. 284</text>
     <range>60 feet</range>
     <components>V, S, M (a piece of iron and a flame)</components>
     <duration>Concentration, up to 1 minute</duration>
-    <classes>Bard [2024], Druid [2024]</classes>
+    <classes>School: Transmutation, Bard [2024], Druid [2024]</classes>
     <text>Choose a manufactured metal object, such as a metal weapon or a suit of Heavy or Medium metal armor, that you can see within range. You cause the object to glow red-hot. Any creature in physical contact with the object takes 2d8 Fire damage when you cast the spell. Until the spell ends, you can take a Bonus Action on each of your later turns to deal this damage again if the object is within range.
 
 If a creature is holding or wearing the object and takes the damage from it, the creature must succeed on a Constitution saving throw or drop the object if it can. If it doesn't drop the object, it has Disadvantage on attack rolls and ability checks until the start of your next turn.
@@ -3577,7 +3577,7 @@ Source:	Player's Handbook 2024 p. 284</text>
     <range>60 feet</range>
     <components>V, S</components>
     <duration>Instantaneous</duration>
-    <classes>Warlock [2024]</classes>
+    <classes>School: Evocation, Warlock [2024]</classes>
     <text>The creature that damaged you is momentarily surrounded by green flames. It makes a Dexterity saving throw, taking 2d10 Fire damage on a failed save or half as much damage on a successful one.
 
 Using a Higher-Level Spell Slot:
@@ -3602,7 +3602,7 @@ Source:	Player's Handbook 2024 p. 284</text>
     <range>10 feet</range>
     <components>V, S, M (a gem-encrusted bowl worth 1,000+ GP, which the spell consumes)</components>
     <duration>Instantaneous</duration>
-    <classes>Bard [2024], Cleric [2024], Druid [2024]</classes>
+    <classes>School: Conjuration, Bard [2024], Cleric [2024], Druid [2024]</classes>
     <text>You conjure a feast that appears on a surface in an unoccupied 10-foot Cube next to you. The feast takes 1 hour to consume and disappears at the end of that time, and the beneficial effects don't set in until this hour is over. Up to twelve creatures can partake of the feast.
 
 A creature that partakes gains several benefits, which last for 24 hours. The creature has Resistance to Poison damage, and it has Immunity to the Frightened and Poisoned conditions. Its Hit Point maximum also increases by 2d10, and it gains the same number of Hit Points.
@@ -3617,7 +3617,7 @@ Source:	Player's Handbook 2024 p. 284</text>
     <range>Touch</range>
     <components>V, S</components>
     <duration>Concentration, up to 1 minute</duration>
-    <classes>Bard [2024], Paladin [2024], Paladin [2024] (Glory)</classes>
+    <classes>School: Enchantment, Bard [2024], Paladin [2024], Paladin [2024] (Glory)</classes>
     <text>A willing creature you touch is imbued with bravery. Until the spell ends, the creature is immune to the Frightened condition and gains Temporary Hit Points equal to your spellcasting ability modifier at the start of each of its turns.
 
 Using a Higher-Level Spell Slot:
@@ -3633,7 +3633,7 @@ Source:	Player's Handbook 2024 p. 285</text>
     <range>90 feet</range>
     <components>V, S, M (the petrified eye of a newt)</components>
     <duration>Concentration, up to 1 hour</duration>
-    <classes>Warlock [2024]</classes>
+    <classes>School: Enchantment, Warlock [2024]</classes>
     <text>You place a curse on a creature that you can see within range. Until the spell ends, you deal an extra 1d6 Necrotic damage to the target whenever you hit it with an attack roll. Also, choose one ability when you cast the spell. The target has Disadvantage on ability checks made with the chosen ability.
 
 If the target drops to 0 Hit Points before this spell ends, you can take a Bonus Action on a later turn to curse a new creature.
@@ -3652,7 +3652,7 @@ Source:	Player's Handbook 2024 p. 285</text>
     <range>90 feet</range>
     <components>V, S, M (a straight piece of iron)</components>
     <duration>Concentration, up to 1 minute</duration>
-    <classes>Bard [2024], Sorcerer [2024], Warlock [2024], Wizard [2024], Cleric [2024] (War), Druid [2024] (Sea), Paladin [2024] (Vengeance)</classes>
+    <classes>School: Enchantment, Bard [2024], Sorcerer [2024], Warlock [2024], Wizard [2024], Cleric [2024] (War), Druid [2024] (Sea), Paladin [2024] (Vengeance)</classes>
     <text>Choose a creature that you can see within range. The target must succeed on a Wisdom saving throw or have the Paralyzed condition for the duration. At the end of each of its turns, the target repeats the save, ending the spell on itself on a success.
 
 Using a Higher-Level Spell Slot:
@@ -3668,7 +3668,7 @@ Source:	Player's Handbook 2024 p. 285</text>
     <range>60 feet</range>
     <components>V, S, M (a straight piece of iron)</components>
     <duration>Concentration, up to 1 minute</duration>
-    <classes>Bard [2024], Cleric [2024], Druid [2024], Sorcerer [2024], Warlock [2024], Wizard [2024], Druid [2024] (Polar Land), Paladin [2024] (Vengeance)</classes>
+    <classes>School: Enchantment, Bard [2024], Cleric [2024], Druid [2024], Sorcerer [2024], Warlock [2024], Wizard [2024], Druid [2024] (Polar Land), Paladin [2024] (Vengeance)</classes>
     <text>Choose a Humanoid that you can see within range. The target must succeed on a Wisdom saving throw or have the Paralyzed condition for the duration. At the end of each of its turns, the target repeats the save, ending the spell on itself on a success.
 
 Using a Higher-Level Spell Slot:
@@ -3684,7 +3684,7 @@ Source:	Player's Handbook 2024 p. 286</text>
     <range>Self</range>
     <components>V, S, M (a reliquary worth 1,000+ GP)</components>
     <duration>Concentration, up to 1 minute</duration>
-    <classes>Cleric [2024]</classes>
+    <classes>School: Abjuration, Cleric [2024]</classes>
     <text>For the duration, you emit an aura in a 30-foot Emanation. While in the aura, creatures of your choice have Advantage on all saving throws, and other creatures have Disadvantage on attack rolls against them. In addition, when a Fiend or an Undead hits an affected creature with a melee attack roll, the attacker must succeed on a Constitution saving throw or have the Blinded condition until the end of its next turn.
 
 Source:	Player's Handbook 2024 p. 286</text>
@@ -3697,7 +3697,7 @@ Source:	Player's Handbook 2024 p. 286</text>
     <range>150 feet</range>
     <components>V, S, M (a pickled tentacle)</components>
     <duration>Concentration, up to 1 minute</duration>
-    <classes>Warlock [2024], Sorcerer [2024] (Aberrant), Warlock [2024] (Great Old One)</classes>
+    <classes>School: Conjuration, Warlock [2024], Sorcerer [2024] (Aberrant), Warlock [2024] (Great Old One)</classes>
     <text>You open a gateway to the Far Realm, a region infested with unspeakable horrors. A 20-foot-radius Sphere of Darkness appears, centered on a point with range and lasting for the duration. The Sphere is Difficult Terrain, and it is filled with strange whispers and slurping noises, which can be heard up to 30 feet away. No light, magical or otherwise, can illuminate the area, and creatures fully within it have the Blinded condition.
 
 Any creature that starts its turn in the area takes 2d6 Cold damage. Any creature that ends its turn there must succeed on a Dexterity saving throw or take 2d6 Acid damage from otherworldly tentacles.
@@ -3722,7 +3722,7 @@ Source:	Player's Handbook 2024 p. 286</text>
     <range>90 feet</range>
     <components>V</components>
     <duration>Concentration, up to 1 hour</duration>
-    <classes>Ranger [2024], Paladin [2024] (Vengeance)</classes>
+    <classes>School: Divination, Ranger [2024], Paladin [2024] (Vengeance)</classes>
     <text>You magically mark one creature you can see within range as your quarry. Until the spell ends, you deal an extra 1d6 Force damage to the target whenever you hit it with an attack roll. You also have Advantage on any Wisdom (Perception or Survival) check you make to find it.
 
 If the target drops to 0 Hit Points before this spell ends, you can take a Bonus Action to move the mark to a new creature you can see within range.
@@ -3741,7 +3741,7 @@ Source:	Player's Handbook 2024 p. 287</text>
     <range>120 feet</range>
     <components>S, M (a pinch of confetti)</components>
     <duration>Concentration, up to 1 minute</duration>
-    <classes>Bard [2024], Sorcerer [2024], Warlock [2024], Wizard [2024], Cleric [2024] (Trickery)</classes>
+    <classes>School: Illusion, Bard [2024], Sorcerer [2024], Warlock [2024], Wizard [2024], Cleric [2024] (Trickery)</classes>
     <text>You create a twisting pattern of colors in a 30-foot Cube within range. The pattern appears for a moment and vanishes. Each creature in the area who can see the pattern must succeed on a Wisdom saving throw or have the Charmed condition for the duration. While Charmed, the creature has the Incapacitated condition and a Speed of 0.
 
 The spell ends for an affected creature if it takes any damage or if someone else uses an action to shake the creature out of its stupor.
@@ -3756,7 +3756,7 @@ Source:	Player's Handbook 2024 p. 287</text>
     <range>60 feet</range>
     <components>S, M (a drop of water or a piece of ice)</components>
     <duration>Instantaneous</duration>
-    <classes>Druid [2024], Sorcerer [2024], Wizard [2024]</classes>
+    <classes>School: Conjuration, Druid [2024], Sorcerer [2024], Wizard [2024]</classes>
     <text>You create a shard of ice and fling it at one creature within range. Make a ranged spell attack against the target. On a hit, the target takes 1d10 Piercing damage. Hit or miss, the shard then explodes. The target and each creature within 5 feet of it must succeed on a Dexterity saving throw or take 2d6 Cold damage.
 
 Using a Higher-Level Spell Slot:
@@ -3782,7 +3782,7 @@ Source:	Player's Handbook 2024 p. 287</text>
     <range>300 feet</range>
     <components>V, S, M (a mitten)</components>
     <duration>Instantaneous</duration>
-    <classes>Druid [2024], Sorcerer [2024], Wizard [2024], Druid [2024] (Polar Land), Druid [2024] (Sea), Paladin [2024] (Ancient)</classes>
+    <classes>School: Evocation, Druid [2024], Sorcerer [2024], Wizard [2024], Druid [2024] (Polar Land), Druid [2024] (Sea), Paladin [2024] (Ancient)</classes>
     <text>Hail falls in a 20-foot-radius, 40-foot-high Cylinder centered on a point within range. Each creature in the Cylinder makes a Dexterity saving throw. A creature takes 2d10 Bludgeoning damage and 4d6 Cold damage on a failed save or half as much damage on a successful one.
 
 Hailstones turn ground in the Cylinder into Difficult Terrain until the end of your next turn.
@@ -3808,7 +3808,7 @@ Source:	Player's Handbook 2024 p. 287</text>
     <range>Touch</range>
     <components>V, S, M (a pearl worth 100+ GP)</components>
     <duration>Instantaneous</duration>
-    <classes>Bard [2024], Wizard [2024]</classes>
+    <classes>School: Divination, Bard [2024], Wizard [2024]</classes>
     <text>You touch an object throughout the spell's casting. If the object is a magic item or some other magical object, you learn its properties and how to use them, whether it requires Attunement, and how many charges it has, if any. You learn whether any ongoing spells are affecting the item and what they are. If the item was created by a spell, you learn that spell's name.
 
 If you instead touch a creature throughout the casting, you learn which ongoing spells, if any, are currently affecting it.
@@ -3824,7 +3824,7 @@ Source:	Player's Handbook 2024 p. 287</text>
     <range>Touch</range>
     <components>S, M (ink worth 10+ GP, which the spell consumes)</components>
     <duration>10 day</duration>
-    <classes>Bard [2024], Warlock [2024], Wizard [2024]</classes>
+    <classes>School: Illusion, Bard [2024], Warlock [2024], Wizard [2024]</classes>
     <text>You write on parchment, paper, or another suitable material and imbue it with an illusion that lasts for the duration. To you and any creatures you designate when you cast the spell, the writing appears normal, seems to be written in your hand, and conveys whatever meaning you intended when you wrote the text. To all others, the writing appears as if it were written in an unknown or magical script that is unintelligible. Alternatively, the illusion can alter the meaning, handwriting, and language of the text, though the language must be one you know.
 
 If the spell is dispelled, the original script and the illusion both disappear.
@@ -3841,7 +3841,7 @@ Source:	Player's Handbook 2024 p. 288</text>
     <range>30 feet</range>
     <components>V, S, M (a statuette of the target worth 5,000+ GP)</components>
     <duration/>
-    <classes>Warlock [2024], Wizard [2024]</classes>
+    <classes>School: Abjuration, Warlock [2024], Wizard [2024]</classes>
     <text>You create a magical restraint to hold a creature that you can see within range. The target must make a Wisdom saving throw. On a successful save, the target is unaffected, and it is immune to this spell for the next 24 hours. On a failed save, the target is imprisoned. While imprisoned, the target doesn't need to breathe, eat, or drink, and it doesn't age. Divination spells can't locate or perceive the imprisoned target, and the target can't teleport.
 
 Until the spell ends, the target is also affected by one of the following effects of your choice:
@@ -3874,7 +3874,7 @@ Source:	Player's Handbook 2024 p. 288</text>
     <range>150 feet</range>
     <components>V, S</components>
     <duration>Concentration, up to 1 minute</duration>
-    <classes>Druid [2024], Sorcerer [2024], Wizard [2024]</classes>
+    <classes>School: Conjuration, Druid [2024], Sorcerer [2024], Wizard [2024]</classes>
     <text>A swirling cloud of embers and smoke fills a 20-foot-radius Sphere centered on a point within range. The cloud's area is Heavily Obscured. It lasts for the duration or until a strong wind (like that created by Gust of Wind) disperses it.
 
 When the cloud appears, each creature in it makes a Dexterity saving throw, taking 10d8 Fire damage on a failed save or half as much damage on a successful one. A creature must also make this save when the Sphere moves into its space and when it enters the Sphere or ends its turn there. A creature makes this save only once per turn.
@@ -3892,7 +3892,7 @@ Source:	Player's Handbook 2024 p. 288</text>
     <range>Touch</range>
     <components>V, S</components>
     <duration>Instantaneous</duration>
-    <classes>Cleric [2024]</classes>
+    <classes>School: Necromancy, Cleric [2024]</classes>
     <text>A creature you touch makes a Constitution saving throw, taking 2d10 Necrotic damage on a failed save or half as much damage on a successful one.
 
 Using a Higher-Level Spell Slot:
@@ -3917,7 +3917,7 @@ Source:	Player's Handbook 2024 p. 288</text>
     <range>300 feet</range>
     <components>V, S, M (a locust)</components>
     <duration>Concentration, up to 10 minute</duration>
-    <classes>Cleric [2024], Druid [2024], Sorcerer [2024], Druid [2024] (Tropical Land), Warlock [2024] (Fiend)</classes>
+    <classes>School: Conjuration, Cleric [2024], Druid [2024], Sorcerer [2024], Druid [2024] (Tropical Land), Warlock [2024] (Fiend)</classes>
     <text>Swarming locusts fill a 20-foot-radius Sphere centered on a point you choose within range. The Sphere remains for the duration, and its area is Lightly Obscured and Difficult Terrain.
 
 When the swarm appears, each creature in it makes a Constitution saving throw, taking 4d10 Piercing damage on a failed save or half as much damage on a successful one. A creature also makes this save when it enters the spell's area for the first time on a turn or ends its turn there. A creature makes this save only once per turn.
@@ -3940,7 +3940,7 @@ Source:	Player's Handbook 2024 p. 289</text>
     <range>Touch</range>
     <components>V, S, M (an eyelash in gum arabic)</components>
     <duration>Concentration, up to 1 hour</duration>
-    <classes>Bard [2024], Sorcerer [2024], Warlock [2024], Wizard [2024], Cleric [2024] (Trickery)</classes>
+    <classes>School: Illusion, Bard [2024], Sorcerer [2024], Warlock [2024], Wizard [2024], Cleric [2024] (Trickery)</classes>
     <text>A creature you touch has the Invisible condition until the spell ends. The spell ends early immediately after the target makes an attack roll, deals damage, or casts a spell.
 
 Using a Higher-Level Spell Slot:
@@ -3960,7 +3960,7 @@ Source:	Player's Handbook 2024 p. 289</text>
     <range>120 feet</range>
     <components>V, S, M (a pinch of phosphorus)</components>
     <duration>Concentration, up to 1 minute</duration>
-    <classes>Warlock [2024], Wizard [2024]</classes>
+    <classes>School: Evocation, Warlock [2024], Wizard [2024]</classes>
     <text>You unleash a storm of flashing light and raging thunder in a 10-foot-radius, 40-foot-high Cylinder centered on a point you can see within range. While in this area, creatures have the Blinded and Deafened conditions, and they can't cast spells with a Verbal component.
 
 When the storm appears, each creature in it makes a Constitution saving throw, taking 2d10 Radiant damage and 2d10 Thunder damage on a failed save or half as much damage on a successful one. A creature also makes this save when it enters the spell's area for the first time on a turn or ends its turn there. A creature makes this save only once per turn.
@@ -3988,7 +3988,7 @@ Source:	Player's Handbook 2024 p. 289</text>
     <range>Touch</range>
     <components>V, S, M (a grasshopper's hind leg)</components>
     <duration>1 minute</duration>
-    <classes>Druid [2024], Ranger [2024], Sorcerer [2024], Wizard [2024]</classes>
+    <classes>School: Transmutation, Druid [2024], Ranger [2024], Sorcerer [2024], Wizard [2024]</classes>
     <text>You touch a willing creature. Once on each of its turns until the spell ends, that creature can jump up to 30 feet by spending 10 feet of movement.
 
 Using a Higher-Level Spell Slot:
@@ -4004,7 +4004,7 @@ Source:	Player's Handbook 2024 p. 290</text>
     <range>60 feet</range>
     <components>V</components>
     <duration>Instantaneous</duration>
-    <classes>Bard [2024], Sorcerer [2024], Wizard [2024]</classes>
+    <classes>School: Transmutation, Bard [2024], Sorcerer [2024], Wizard [2024]</classes>
     <text>Choose an object that you can see within range. The object can be a door, a box, a chest, a set of manacles, a padlock, or another object that contains a mundane or magical means that prevents access.
 
 A target that is held shut by a mundane lock or that is stuck or barred becomes unlocked, unstuck, or unbarred. If the object has multiple locks, only one of them is unlocked.
@@ -4023,7 +4023,7 @@ Source:	Player's Handbook 2024 p. 290</text>
     <range>Self</range>
     <components>V, S, M (incense worth 250+ GP, which the spell consumes, and four ivory strips worth 50+ GP each)</components>
     <duration>Instantaneous</duration>
-    <classes>Bard [2024], Cleric [2024], Wizard [2024], Paladin [2024] (Glory), Sorcerer [2024] (Draconic)</classes>
+    <classes>School: Divination, Bard [2024], Cleric [2024], Wizard [2024], Paladin [2024] (Glory), Sorcerer [2024] (Draconic)</classes>
     <text>Name or describe a famous person, place, or object. The spell brings to your mind a brief summary of the significant lore about that famous thing, as described by the DM.
 
 The lore might consist of important details, amusing revelations, or even secret lore that has never been widely known. The more information you already know about the thing, the more precise and detailed the information you receive is. That information is accurate but might be couched in figurative language or poetry, as determined by the DM.
@@ -4040,7 +4040,7 @@ Source:	Player's Handbook 2024 p. 290</text>
     <range>Touch</range>
     <components>V, S, M (a chest, 3 feet by 2 feet by 2 feet, constructed from rare materials worth 5,000+ GP, and a Tiny replica of the chest made from the same materials worth 50+ GP)</components>
     <duration/>
-    <classes>Wizard [2024]</classes>
+    <classes>School: Conjuration, Wizard [2024]</classes>
     <text>You hide a chest and all its contents on the Ethereal Plane. You must touch the chest and the miniature replica that serve as Material components for the spell. The chest can contain up to 12 cubic feet of nonliving material (3 feet by 2 feet by 2 feet).
 
 While the chest remains on the Ethereal Plane, you can take a Magic action and touch the replica to recall the chest. It appears in an unoccupied space on the ground within 5 feet of you. You can send the chest back to the Ethereal Plane by taking a Magic action to touch the chest and the replica.
@@ -4058,7 +4058,7 @@ Source:	Player's Handbook 2024 p. 290</text>
     <range>Self</range>
     <components>V, S, M (a crystal bead)</components>
     <duration>8 hour</duration>
-    <classes>Bard [2024], Wizard [2024]</classes>
+    <classes>School: Evocation, Bard [2024], Wizard [2024]</classes>
     <text>A 10-foot Emanation springs into existence around you and remains stationary for the duration. The spell fails when you cast it if the Emanation isn't big enough to fully encapsulate all creatures in its area.
 
 Creatures and objects within the Emanation when you cast the spell can move through it freely. All other creatures and objects are barred from passing through it. Spells of level 3 or lower can't be cast through it, and the effects of such spells can't extend into it.
@@ -4077,7 +4077,7 @@ Source:	Player's Handbook 2024 p. 291</text>
     <range>Touch</range>
     <components>V, S</components>
     <duration>Instantaneous</duration>
-    <classes>Bard [2024], Cleric [2024], Druid [2024], Ranger [2024], Paladin [2024], Cleric [2024] (Life), Sorcerer [2024] (Clockwork), Warlock [2024] (Celestial)</classes>
+    <classes>School: Abjuration, Bard [2024], Cleric [2024], Druid [2024], Ranger [2024], Paladin [2024], Cleric [2024] (Life), Sorcerer [2024] (Clockwork), Warlock [2024] (Celestial)</classes>
     <text>You touch a creature and end one condition on it: Blinded, Deafened, Paralyzed, or Poisoned.
 
 Source:	Player's Handbook 2024 p. 291</text>
@@ -4090,7 +4090,7 @@ Source:	Player's Handbook 2024 p. 291</text>
     <range>60 feet</range>
     <components>V, S, M (a metal spring)</components>
     <duration>Concentration, up to 10 minute</duration>
-    <classes>Sorcerer [2024], Wizard [2024]</classes>
+    <classes>School: Transmutation, Sorcerer [2024], Wizard [2024]</classes>
     <text>One creature or loose object of your choice that you can see within range rises vertically up to 20 feet and remains suspended there for the duration. The spell can levitate an object that weighs up to 500 pounds. An unwilling creature that succeeds on a Constitution saving throw is unaffected.
 
 The target can move only by pushing or pulling against a fixed object or surface within reach (such as a wall or a ceiling), which allows it to move as if it were climbing. You can change the target's altitude by up to 20 feet in either direction on your turn. If you are the target, you can move up or down as part of your move. Otherwise, you can take a Magic action to move the target, which must remain within the spell's range.
@@ -4107,7 +4107,7 @@ Source:	Player's Handbook 2024 p. 291</text>
     <range>Touch</range>
     <components>V, M (a firefly or phosphorescent moss)</components>
     <duration>1 hour</duration>
-    <classes>Bard [2024], Cleric [2024], Sorcerer [2024], Wizard [2024], Warlock [2024] (Celestial)</classes>
+    <classes>School: Evocation, Bard [2024], Cleric [2024], Sorcerer [2024], Wizard [2024], Warlock [2024] (Celestial)</classes>
     <text>You touch one Large or smaller object that isn't being worn or carried by someone else. Until the spell ends, the object sheds Bright Light in a 20-foot radius and Dim Light for an additional 20 feet. The light can be colored as you like.
 
 Covering the object with something opaque blocks the light. The spell ends if you cast it again.
@@ -4122,7 +4122,7 @@ Source:	Player's Handbook 2024 p. 292</text>
     <range>Self</range>
     <components>V, S</components>
     <duration>Instantaneous</duration>
-    <classes>Ranger [2024]</classes>
+    <classes>School: Transmutation, Ranger [2024]</classes>
     <text>As your attack hits or misses the target, the weapon or ammunition you're using transforms into a lightning bolt. Instead of taking any damage or other effects from the attack, the target takes 4d8 Lightning damage on a hit or half as much damage on a miss. Each creature within 10 feet of the target then makes a Dexterity saving throw, taking 2d8 Lightning damage on a failed save or half as much damage on a successful one.
 
 The weapon or ammunition then returns to its normal form.
@@ -4149,7 +4149,7 @@ Source:	Player's Handbook 2024 p. 292</text>
     <range>100 feet</range>
     <components>V, S, M (a bit of fur and a crystal rod)</components>
     <duration>Instantaneous</duration>
-    <classes>Sorcerer [2024], Wizard [2024], Druid [2024] (Temperate Land), Druid [2024] (Sea)</classes>
+    <classes>School: Evocation, Sorcerer [2024], Wizard [2024], Druid [2024] (Temperate Land), Druid [2024] (Sea)</classes>
     <text>A stroke of lightning forming a 100-foot-long, 5-foot-wide Line blasts out from you in a direction you choose. Each creature in the Line makes a Dexterity saving throw, taking 8d6 Lightning damage on a failed save or half as much damage on a successful one.
 
 Using a Higher-Level Spell Slot:
@@ -4173,7 +4173,7 @@ Source:	Player's Handbook 2024 p. 292</text>
     <range>Self</range>
     <components>V, S, M (fur from a bloodhound)</components>
     <duration>Instantaneous</duration>
-    <classes>Bard [2024], Druid [2024], Ranger [2024]</classes>
+    <classes>School: Divination, Bard [2024], Druid [2024], Ranger [2024]</classes>
     <text>Describe or name a specific kind of Beast, Plant creature, or nonmagical plant. You learn the direction and distance to the closest creature or plant of that kind within 5 miles, if any are present.
 
 Source:	Player's Handbook 2024 p. 292</text>
@@ -4186,7 +4186,7 @@ Source:	Player's Handbook 2024 p. 292</text>
     <range>Self</range>
     <components>V, S, M (fur from a bloodhound)</components>
     <duration>Concentration, up to 1 hour</duration>
-    <classes>Bard [2024], Cleric [2024], Druid [2024], Ranger [2024], Wizard [2024], Paladin [2024]</classes>
+    <classes>School: Divination, Bard [2024], Cleric [2024], Druid [2024], Ranger [2024], Wizard [2024], Paladin [2024]</classes>
     <text>Describe or name a creature that is familiar to you. You sense the direction to the creature's location if that creature is within 1,000 feet of you. If the creature is moving, you know the direction of its movement.
 
 The spell can locate a specific creature known to you or the nearest creature of a specific kind (such as a human or a unicorn) if you have seen such a creature up close—within 30 feet—at least once. If the creature you described or named is in a different form, such as under the effects of a Flesh to Stone or Polymorph spell, this spell doesn't locate the creature.
@@ -4203,7 +4203,7 @@ Source:	Player's Handbook 2024 p. 292</text>
     <range>Self</range>
     <components>V, S, M (a forked twig)</components>
     <duration>Concentration, up to 10 minute</duration>
-    <classes>Bard [2024], Cleric [2024], Druid [2024], Ranger [2024], Wizard [2024], Paladin [2024]</classes>
+    <classes>School: Divination, Bard [2024], Cleric [2024], Druid [2024], Ranger [2024], Wizard [2024], Paladin [2024]</classes>
     <text>Describe or name an object that is familiar to you. You sense the direction to the object's location if that object is within 1,000 feet of you. If the object is in motion, you know the direction of its movement.
 
 The spell can locate a specific object known to you if you have seen it up close—within 30 feet—at least once. Alternatively, the spell can locate the nearest object of a particular kind, such as a certain kind of apparel, jewelry, furniture, tool, or weapon.
@@ -4220,7 +4220,7 @@ Source:	Player's Handbook 2024 p. 293</text>
     <range>Touch</range>
     <components>V, S, M (a pinch of dirt)</components>
     <duration>1 hour</duration>
-    <classes>Bard [2024], Druid [2024], Ranger [2024], Wizard [2024]</classes>
+    <classes>School: Transmutation, Bard [2024], Druid [2024], Ranger [2024], Wizard [2024]</classes>
     <text>You touch a creature. The target's Speed increases by 10 feet until the spell ends.
 
 Using a Higher-Level Spell Slot:
@@ -4236,7 +4236,7 @@ Source:	Player's Handbook 2024 p. 293</text>
     <range>Touch</range>
     <components>V, S, M (a piece of cured leather)</components>
     <duration>8 hour</duration>
-    <classes>Sorcerer [2024], Wizard [2024]</classes>
+    <classes>School: Abjuration, Sorcerer [2024], Wizard [2024]</classes>
     <text>You touch a willing creature who isn't wearing armor. Until the spell ends, the target's base AC becomes 13 plus its Dexterity modifier. The spell ends early if the target dons armor.
 
 Source:	Player's Handbook 2024 p. 293</text>
@@ -4249,7 +4249,7 @@ Source:	Player's Handbook 2024 p. 293</text>
     <range>30 feet</range>
     <components>V, S</components>
     <duration>1 minute</duration>
-    <classes>Bard [2024], Sorcerer [2024], Warlock [2024], Wizard [2024]</classes>
+    <classes>School: Conjuration, Bard [2024], Sorcerer [2024], Warlock [2024], Wizard [2024]</classes>
     <text>A spectral, floating hand appears at a point you choose within range. The hand lasts for the duration. The hand vanishes if it is ever more than 30 feet away from you or if you cast this spell again.
 
 When you cast the spell, you can use the hand to manipulate an object, open an unlocked door or container, stow or retrieve an item from an open container, or pour the contents out of a vial.
@@ -4268,7 +4268,7 @@ Source:	Player's Handbook 2024 p. 293</text>
     <range>10 feet</range>
     <components>V, S, M (salt and powdered silver worth 100+ GP, which the spell consumes)</components>
     <duration>1 hour</duration>
-    <classes>Cleric [2024], Warlock [2024], Wizard [2024], Paladin [2024]</classes>
+    <classes>School: Abjuration, Cleric [2024], Warlock [2024], Wizard [2024], Paladin [2024]</classes>
     <text>You create a 10-foot-radius, 20-foot-tall Cylinder of magical energy centered on a point on the ground that you can see within range. Glowing runes appear wherever the Cylinder intersects with the floor or other surface.
 
 Choose one or more of the following types of creatures: Celestials, Elementals, Fey, Fiends, or Undead. The circle affects a creature of the chosen type in the following ways:
@@ -4294,7 +4294,7 @@ Source:	Player's Handbook 2024 p. 293</text>
     <range>Self</range>
     <components>V, S, M (a gem, crystal, or reliquary worth 500+ GP)</components>
     <duration/>
-    <classes>Wizard [2024]</classes>
+    <classes>School: Necromancy, Wizard [2024]</classes>
     <text>Your body falls into a catatonic state as your soul leaves it and enters the container you used for the spell's Material component. While your soul inhabits the container, you are aware of your surroundings as if you were in the container's space. You can't move or take Reactions. The only action you can take is to project your soul up to 100 feet out of the container, either returning to your living body (and ending the spell) or attempting to possess a Humanoid's body.
 
 You can attempt to possess any Humanoid within 100 feet of you that you can see (creatures warded by a Protection from Evil and Good or Magic Circle spell can't be possessed). The target makes a Charisma saving throw. On a failed save, your soul enters the target's body, and the target's soul becomes trapped in the container. On a successful save, the target resists your efforts to possess it, and you can't attempt to possess it again for 24 hours.
@@ -4319,7 +4319,7 @@ Source:	Player's Handbook 2024 p. 294</text>
     <range>120 feet</range>
     <components>V, S</components>
     <duration>Instantaneous</duration>
-    <classes>Sorcerer [2024], Wizard [2024]</classes>
+    <classes>School: Evocation, Sorcerer [2024], Wizard [2024]</classes>
     <text>You create three glowing darts of magical force. Each dart strikes a creature of your choice that you can see within range. A dart deals 1d4 + 1 Force damage to its target. The darts all strike simultaneously, and you can direct them to hit one creature or several.
 
 Using a Higher-Level Spell Slot:
@@ -4337,7 +4337,7 @@ Source:	Player's Handbook 2024 p. 295</text>
     <range>30 feet</range>
     <components>V, S, M (jade dust worth 10+ GP, which the spell consumes)</components>
     <duration/>
-    <classes>Bard [2024], Wizard [2024]</classes>
+    <classes>School: Illusion, Bard [2024], Wizard [2024]</classes>
     <text>You implant a message within an object in range—a message that is uttered when a trigger condition is met. Choose an object that you can see and that isn't being worn or carried by another creature. Then speak the message, which must be 25 words or fewer, though it can be delivered over as long as 10 minutes. Finally, determine the circumstance that will trigger the spell to deliver your message.
 
 When that trigger occurs, a magical mouth appears on the object and recites the message in your voice and at the same volume you spoke. If the object you chose has a mouth or something that looks like a mouth (for example, the mouth of a statue), the magical mouth appears there, so the words appear to come from the object's mouth. When you cast this spell, you can have the spell end after it delivers its message, or it can remain and repeat its message whenever the trigger occurs.
@@ -4354,7 +4354,7 @@ Source:	Player's Handbook 2024 p. 295</text>
     <range>Touch</range>
     <components>V, S</components>
     <duration>1 hour</duration>
-    <classes>Ranger [2024], Sorcerer [2024], Wizard [2024], Paladin [2024], Cleric [2024] (War), Paladin [2024] (Glory)</classes>
+    <classes>School: Transmutation, Ranger [2024], Sorcerer [2024], Wizard [2024], Paladin [2024], Cleric [2024] (War), Paladin [2024] (Glory)</classes>
     <text>You touch a nonmagical weapon. Until the spell ends, that weapon becomes a magic weapon with a +1 bonus to attack rolls and damage rolls. The spell ends early if you cast it again.
 
 Using a Higher-Level Spell Slot:
@@ -4370,7 +4370,7 @@ Source:	Player's Handbook 2024 p. 295</text>
     <range>120 feet</range>
     <components>V, S, M (a bit of fleece)</components>
     <duration>Concentration, up to 10 minute</duration>
-    <classes>Bard [2024], Sorcerer [2024], Warlock [2024], Wizard [2024]</classes>
+    <classes>School: Illusion, Bard [2024], Sorcerer [2024], Warlock [2024], Wizard [2024]</classes>
     <text>You create the image of an object, a creature, or some other visible phenomenon that is no larger than a 20-foot Cube. The image appears at a spot that you can see within range and lasts for the duration. It seems real, including sounds, smells, and temperature appropriate to the thing depicted, but it can't deal damage or cause conditions.
 
 If you are within range of the illusion, you can take a Magic action to cause the image to move to any other spot within range. As the image changes location, you can alter its appearance so that its movements appear natural for the image. For example, if you create an image of a creature and move it, you can alter the image so that it appears to be walking. Similarly, you can cause the illusion to make different sounds at different times, even making it carry on a conversation, for example.
@@ -4390,7 +4390,7 @@ Source:	Player's Handbook 2024 p. 295</text>
     <range>60 feet</range>
     <components>V, S</components>
     <duration>Instantaneous</duration>
-    <classes>Bard [2024], Cleric [2024], Druid [2024], Cleric [2024] (Life), Druid [2024] (Moon)</classes>
+    <classes>School: Abjuration, Bard [2024], Cleric [2024], Druid [2024], Cleric [2024] (Life), Druid [2024] (Moon)</classes>
     <text>A wave of healing energy washes out from a point you can see within range. Choose up to six creatures in a 30-foot-radius Sphere centered on that point. Each target regains Hit Points equal to 5d8 plus your spellcasting ability modifier.
 
 Using a Higher-Level Spell Slot:
@@ -4411,7 +4411,7 @@ Source:	Player's Handbook 2024 p. 296</text>
     <range>60 feet</range>
     <components>V, S</components>
     <duration>Instantaneous</duration>
-    <classes>Cleric [2024]</classes>
+    <classes>School: Abjuration, Cleric [2024]</classes>
     <text>A flood of healing energy flows from you into creatures around you. You restore up to 700 Hit Points, divided as you choose among any number of creatures that you can see within range. Creatures healed by this spell also have the Blinded, Deafened, and Poisoned conditions removed from them.
 
 Source:	Player's Handbook 2024 p. 296</text>
@@ -4424,7 +4424,7 @@ Source:	Player's Handbook 2024 p. 296</text>
     <range>60 feet</range>
     <components>V</components>
     <duration>Instantaneous</duration>
-    <classes>Bard [2024], Cleric [2024], Cleric [2024] (Life)</classes>
+    <classes>School: Abjuration, Bard [2024], Cleric [2024], Cleric [2024] (Life)</classes>
     <text>Up to six creatures of your choice that you can see within range regain Hit Points equal to 2d4 plus your spellcasting ability modifier.
 
 Using a Higher-Level Spell Slot:
@@ -4447,7 +4447,7 @@ Source:	Player's Handbook 2024 p. 296</text>
     <range>60 feet</range>
     <components>V, M (a snake's tongue)</components>
     <duration>24 hour</duration>
-    <classes>Bard [2024], Sorcerer [2024], Wizard [2024]</classes>
+    <classes>School: Enchantment, Bard [2024], Sorcerer [2024], Wizard [2024]</classes>
     <text>You suggest a course of activity—described in no more than 25 words—to twelve or fewer creatures you can see within range that can hear and understand you. The suggestion must sound achievable and not involve anything that would obviously deal damage to any of the targets or their allies. For example, you could say, "Walk to the village down that road, and help the villagers there harvest crops until sunset." Or you could say, "Now is not the time for violence. Drop your weapons, and dance! Stop in an hour."
 
 Each target must succeed on a Wisdom saving throw or have the Charmed condition for the duration or until you or your allies deal damage to the target. Each Charmed target pursues the suggestion to the best of its ability. The suggested activity can continue for the entire duration, but if the suggested activity can be completed in a shorter time, the spell ends for a target upon completing it.
@@ -4465,7 +4465,7 @@ Source:	Player's Handbook 2024 p. 296</text>
     <range>60 feet</range>
     <components>V, S</components>
     <duration>Concentration, up to 10 minute</duration>
-    <classes>Wizard [2024]</classes>
+    <classes>School: Conjuration, Wizard [2024]</classes>
     <text>You banish a creature that you can see within range into a labyrinthine demiplane. The target remains there for the duration or until it escapes the maze.
 
 The target can take a Study action to try to escape. When it does so, it makes a DC 20 Intelligence (Investigation) check. If it succeeds, it escapes, and the spell ends.
@@ -4483,7 +4483,7 @@ Source:	Player's Handbook 2024 p. 296</text>
     <range>Touch</range>
     <components>V, S</components>
     <duration>8 hour</duration>
-    <classes>Cleric [2024], Druid [2024], Ranger [2024]</classes>
+    <classes>School: Transmutation, Cleric [2024], Druid [2024], Ranger [2024]</classes>
     <text>You step into a stone object or surface large enough to fully contain your body, merging yourself and your equipment with the stone for the duration. You must touch the stone to do so. Nothing of your presence remains visible or otherwise detectable by nonmagical senses.
 
 While merged with the stone, you can't see what occurs outside it, and any Wisdom (Perception) checks you make to hear sounds outside it are made with Disadvantage. You remain aware of the passage of time and can cast spells on yourself while merged in the stone. You can use 5 feet of movement to leave the stone where you entered it, which ends the spell. You otherwise can't move.
@@ -4501,7 +4501,7 @@ Source:	Player's Handbook 2024 p. 296</text>
     <range>90 feet</range>
     <components>V, S, M (powdered rhubarb leaf)</components>
     <duration>Instantaneous</duration>
-    <classes>Wizard [2024]</classes>
+    <classes>School: Evocation, Wizard [2024]</classes>
     <text>A shimmering green arrow streaks toward a target within range and bursts in a spray of acid. Make a ranged spell attack against the target. On a hit, the target takes 4d4 Acid damage and 2d4 Acid damage at the end of its next turn. On a miss, the arrow splashes the target with acid for half as much of the initial damage only.
 
 Using a Higher-Level Spell Slot:
@@ -4527,7 +4527,7 @@ Source:	Player's Handbook 2024 p. 297</text>
     <range>Touch</range>
     <components>V, S, M (two lodestones)</components>
     <duration>Instantaneous</duration>
-    <classes>Bard [2024], Cleric [2024], Druid [2024], Sorcerer [2024], Wizard [2024]</classes>
+    <classes>School: Transmutation, Bard [2024], Cleric [2024], Druid [2024], Sorcerer [2024], Wizard [2024]</classes>
     <text>This spell repairs a single break or tear in an object you touch, such as a broken chain link, two halves of a broken key, a torn cloak, or a leaking wineskin. As long as the break or tear is no larger than 1 foot in any dimension, you mend it, leaving no trace of the former damage.
 
 This spell can physically repair a magic item, but it can't restore magic to such an object.
@@ -4542,7 +4542,7 @@ Source:	Player's Handbook 2024 p. 297</text>
     <range>120 feet</range>
     <components>S, M (a copper wire)</components>
     <duration>1 round</duration>
-    <classes>Bard [2024], Druid [2024], Sorcerer [2024], Wizard [2024]</classes>
+    <classes>School: Transmutation, Bard [2024], Druid [2024], Sorcerer [2024], Wizard [2024]</classes>
     <text>You point toward a creature within range and whisper a message. The target (and only the target) hears the message and can reply in a whisper that only you can hear.
 
 You can cast this spell through solid objects if you are familiar with the target and know it is beyond the barrier. Magical silence; 1 foot of stone, metal, or wood; or a thin sheet of lead blocks the spell.
@@ -4557,7 +4557,7 @@ Source:	Player's Handbook 2024 p. 298</text>
     <range>1 Miles</range>
     <components>V, S</components>
     <duration>Instantaneous</duration>
-    <classes>Sorcerer [2024], Wizard [2024]</classes>
+    <classes>School: Evocation, Sorcerer [2024], Wizard [2024]</classes>
     <text>Blazing orbs of fire plummet to the ground at four different points you can see within range. Each creature in a 40-foot-radius Sphere centered on each of those points makes a Dexterity saving throw. A creature takes 20d6 Fire damage and 20d6 Bludgeoning damage on a failed save or half as much damage on a successful one. A creature in the area of more than one fiery Sphere is affected only once.
 
 A nonmagical object that isn't being worn or carried also takes the damage if it's in the spell's area, and the object starts burning if it's flammable.
@@ -4574,7 +4574,7 @@ Source:	Player's Handbook 2024 p. 298</text>
     <range>Touch</range>
     <components>V, S</components>
     <duration>24 hour</duration>
-    <classes>Bard [2024], Wizard [2024]</classes>
+    <classes>School: Abjuration, Bard [2024], Wizard [2024]</classes>
     <text>Until the spell ends, one willing creature you touch has Immunity to Psychic damage and the Charmed condition. The target is also unaffected by anything that would sense its emotions or alignment, read its thoughts, or magically detect its location, and no spell—not even Wish—can gather information about the target, observe it remotely, or control its mind.
 
 Source:	Player's Handbook 2024 p. 298</text>
@@ -4587,7 +4587,7 @@ Source:	Player's Handbook 2024 p. 298</text>
     <range>60 feet</range>
     <components>V</components>
     <duration>Instantaneous</duration>
-    <classes>Sorcerer [2024], Warlock [2024], Wizard [2024], Sorcerer [2024] (Aberrant)</classes>
+    <classes>School: Enchantment, Sorcerer [2024], Warlock [2024], Wizard [2024], Sorcerer [2024] (Aberrant)</classes>
     <text>You try to temporarily sliver the mind of one creature you can see within range. The target must succeed on an Intelligence saving throw or take 1d6 Psychic damage and subtract 1d4 from the next saving throw it makes before the end of your next turn.
 
 Cantrip Upgrade: The damage increases by 1d6 when you reach levels 5 (2d6), 11 (3d6), and 17 (4d6).
@@ -4607,7 +4607,7 @@ Source:	Player's Handbook 2024 p. 298</text>
     <range>120 feet</range>
     <components>S</components>
     <duration>Concentration, up to 1 hour</duration>
-    <classes>Sorcerer [2024], Warlock [2024], Wizard [2024]</classes>
+    <classes>School: Divination, Sorcerer [2024], Warlock [2024], Wizard [2024]</classes>
     <text>You drive a spike of psionic energy into the mind of one creature you can see within range. The target makes a Wisdom saving throw, taking 3d8 Psychic damage on a failed save or half as much damage on a successful one. On a failed save, you also always know the target's location until the spell ends, but only while the two of you are on the same plane of existence. While you have this knowledge, the target can't become hidden from you, and if it has the Invisible condition, it gains no benefit from that condition against you.
 
 Using a Higher-Level Spell Slot:
@@ -4631,7 +4631,7 @@ Source:	Player's Handbook 2024 p. 298</text>
     <range>30 feet</range>
     <components>S, M (a bit of fleece)</components>
     <duration>1 minute</duration>
-    <classes>Bard [2024], Sorcerer [2024], Warlock [2024], Wizard [2024]</classes>
+    <classes>School: Illusion, Bard [2024], Sorcerer [2024], Warlock [2024], Wizard [2024]</classes>
     <text>You create a sound or an image of an object within range that lasts for the duration. See the descriptions below for the effects of each. The illusion ends if you cast this spell again.
 
 If a creature takes a Study action to examine the sound or image, the creature can determine that it is an illusion with a successful Intelligence (Investigation) check against your spell save DC. If a creature discerns the illusion for what it is, the illusion becomes faint to the creature.
@@ -4652,7 +4652,7 @@ Source:	Player's Handbook 2024 p. 298</text>
     <range>Sight</range>
     <components>V, S</components>
     <duration>10 day</duration>
-    <classes>Bard [2024], Druid [2024], Wizard [2024]</classes>
+    <classes>School: Illusion, Bard [2024], Druid [2024], Wizard [2024]</classes>
     <text>You make terrain in an area up to 1 mile square look, sound, smell, and even feel like some other sort of terrain. Open fields or a road could be made to resemble a swamp, hill, crevasse, or some other rough or impassable terrain. A pond can be made to seem like a grassy meadow, a precipice like a gentle slope, or a rock-strewn gully like a wide and smooth road.
 
 Similarly, you can alter the appearance of structures or add them where none are present. The spell doesn't disguise, conceal, or add creatures.
@@ -4671,7 +4671,7 @@ Source:	Player's Handbook 2024 p. 299</text>
     <range>Self</range>
     <components>V, S</components>
     <duration>1 minute</duration>
-    <classes>Bard [2024], Sorcerer [2024], Warlock [2024], Wizard [2024]</classes>
+    <classes>School: Illusion, Bard [2024], Sorcerer [2024], Warlock [2024], Wizard [2024]</classes>
     <text>Three illusory duplicates of yourself appear in your space. Until the spell ends, the duplicates move with you and mimic your actions, shifting position so it's impossible to track which image is real.
 
 Each time a creature hits you with an attack roll during the spell's duration, roll a d6 for each of your remaining duplicates. If any of the d6s rolls a 3 or higher, one of the duplicates is hit instead of you, and the duplicate is destroyed. The duplicates otherwise ignore all other damage and effects. The spell ends when all three duplicates are destroyed.
@@ -4688,7 +4688,7 @@ Source:	Player's Handbook 2024 p. 299</text>
     <range>Self</range>
     <components>S</components>
     <duration>Concentration, up to 1 hour</duration>
-    <classes>Bard [2024], Warlock [2024], Wizard [2024], Ranger [2024] (Fey Wanderer)</classes>
+    <classes>School: Illusion, Bard [2024], Warlock [2024], Wizard [2024], Ranger [2024] (Fey Wanderer)</classes>
     <text>You gain the Invisible condition at the same time that an illusory double of you appears where you are standing. The double lasts for the duration, but the invisibility ends immediately after you make an attack roll, deal damage, or cast a spell.
 
 As a Magic action, you can move the illusory double up to twice your Speed and make it gesture, speak, and behave in whatever way you choose. It is intangible and invulnerable.
@@ -4709,7 +4709,7 @@ Source:	Player's Handbook 2024 p. 299</text>
     <range>Self</range>
     <components>V</components>
     <duration>Instantaneous</duration>
-    <classes>Sorcerer [2024], Warlock [2024], Wizard [2024], Druid [2024] (Temperate Land), Paladin [2024] (Ancient), Paladin [2024] (Vengeance), Ranger [2024] (Fey Wanderer), Warlock [2024] (Archfey)</classes>
+    <classes>School: Conjuration, Sorcerer [2024], Warlock [2024], Wizard [2024], Druid [2024] (Temperate Land), Paladin [2024] (Ancient), Paladin [2024] (Vengeance), Ranger [2024] (Fey Wanderer), Warlock [2024] (Archfey)</classes>
     <text>Briefly surrounded by silvery mist, you teleport up to 30 feet to an unoccupied space you can see.
 
 Source:	Player's Handbook 2024 p. 299</text>
@@ -4722,7 +4722,7 @@ Source:	Player's Handbook 2024 p. 299</text>
     <range>30 feet</range>
     <components>V, S</components>
     <duration>Concentration, up to 1 minute</duration>
-    <classes>Bard [2024], Wizard [2024], Cleric [2024] (Trickery), Warlock [2024] (Great Old One)</classes>
+    <classes>School: Enchantment, Bard [2024], Wizard [2024], Cleric [2024] (Trickery), Warlock [2024] (Great Old One)</classes>
     <text>You attempt to reshape another creature's memories. One creature that you can see within range makes a Wisdom saving throw. If you are fighting the creature, it has Advantage on the save. On a failed save, the target has the Charmed condition for the duration. While Charmed in this way, the target also has the Incapacitated condition and is unaware of its surroundings, though it can hear you. If it takes any damage or is targeted by another spell, this spell ends, and no memories are modified.
 
 While this charm lasts, you can affect the target's memory of an event that it experienced within the last 24 hours and that lasted no more than 10 minutes. You can permanently eliminate all memory of the event, allow the target to recall the event with perfect clarity, change its memory of the event's details, or create a memory of some other event.
@@ -4746,7 +4746,7 @@ Source:	Player's Handbook 2024 p. 299</text>
     <range>120 feet</range>
     <components>V, S, M (a moonseed leaf)</components>
     <duration>Concentration, up to 1 minute</duration>
-    <classes>Druid [2024], Druid [2024] (Moon), Paladin [2024] (Ancient)</classes>
+    <classes>School: Evocation, Druid [2024], Druid [2024] (Moon), Paladin [2024] (Ancient)</classes>
     <text>A silvery beam of pale light shines down in a 5-foot-radius, 40-foot-high Cylinder centered on a point within range. Until the spell ends, Dim Light fills the Cylinder, and you can take a Magic action on later turns to move the Cylinder up to 60 feet.
 
 When the Cylinder appears, each creature in it makes a Constitution saving throw. On a failed save, a creature takes 2d10 Radiant damage, and if the creature is shape-shifted (as a result of the Polymorph spell, for example), it reverts to its true form and can't shape-shift until it leaves the Cylinder. On a successful save, a creature takes half as much damage only. A creature also makes this save when the spell's area moves into its space and when it enters the spell's area or ends its turn there. A creature makes this save only once per turn.
@@ -4772,7 +4772,7 @@ Source:	Player's Handbook 2024 p. 300</text>
     <range>30 feet</range>
     <components>V, S, M (a silver whistle)</components>
     <duration>8 hour</duration>
-    <classes>Wizard [2024]</classes>
+    <classes>School: Conjuration, Wizard [2024]</classes>
     <text>You conjure a phantom watchdog in an unoccupied space that you can see within range. The hound remains for the duration or until the two of you are more than 300 feet apart from each other.
 
 No one but you can see the hound, and it is intangible and invulnerable. When a Small or larger creature comes within 30 feet of it without first speaking the password that you specify when you cast this spell, the hound starts barking loudly. The hound has Truesight with a range of 30 feet.
@@ -4792,7 +4792,7 @@ Source:	Player's Handbook 2024 p. 300</text>
     <range>300 feet</range>
     <components>V, S, M (a miniature door worth 15+ GP)</components>
     <duration>24 hour</duration>
-    <classes>Bard [2024], Wizard [2024]</classes>
+    <classes>School: Conjuration, Bard [2024], Wizard [2024]</classes>
     <text>You conjure a shimmering door in range that lasts for the duration. The door leads to an extradimensional dwelling and is 5 feet wide and 10 feet tall. You and any creature you designate when you cast the spell can enter the extradimensional dwelling as long as the door remains open. You can open or close it (no action required) if you are within 30 feet of it. While closed, the door is imperceptible.
 
 Beyond the door is a magnificent foyer with numerous chambers beyond. The dwelling's atmosphere is clean, fresh, and warm.
@@ -4813,7 +4813,7 @@ Source:	Player's Handbook 2024 p. 300</text>
     <range>120 feet</range>
     <components>V, S, M (a thin sheet of lead)</components>
     <duration>24 hour</duration>
-    <classes>Wizard [2024]</classes>
+    <classes>School: Abjuration, Wizard [2024]</classes>
     <text>You make an area within range magically secure. The area is a Cube that can be as small as 5 feet to as large as 100 feet on each side. The spell lasts for the duration.
 
 When you cast the spell, you decide what sort of security the spell provides, choosing any of the following properties:
@@ -4845,7 +4845,7 @@ Source:	Player's Handbook 2024 p. 301</text>
     <range>90 feet</range>
     <components>V, S, M (a miniature sword worth 250+ GP)</components>
     <duration>Concentration, up to 1 minute</duration>
-    <classes>Bard [2024], Wizard [2024]</classes>
+    <classes>School: Evocation, Bard [2024], Wizard [2024]</classes>
     <text>You create a spectral sword that hovers within range. It lasts for the duration.
 
 When the sword appears, you make a melee spell attack against a target within 5 feet of the sword. On a hit, the target takes Force damage equal to 4d12 plus your spellcasting ability modifier.
@@ -4863,7 +4863,7 @@ Source:	Player's Handbook 2024 p. 302</text>
     <range>120 feet</range>
     <components>V, S, M (a miniature shovel)</components>
     <duration>Concentration, up to 2 hour</duration>
-    <classes>Druid [2024], Sorcerer [2024], Wizard [2024]</classes>
+    <classes>School: Transmutation, Druid [2024], Sorcerer [2024], Wizard [2024]</classes>
     <text>Choose an area of terrain no larger than 40 feet on a side within range. You can reshape dirt, sand, or clay in the area in any manner you choose for the duration. You can raise or lower the area's elevation, create or fill in a trench, erect or flatten a wall, or form a pillar. The extent of any such changes can't exceed half the area's largest dimension. For example, if you affect a 40-foot square, you can create a pillar up to 20 feet high, raise or lower the square's elevation by up to 20 feet, dig a trench up to 20 feet deep, and so on. It takes 10 minutes for these changes to complete. Because the terrain's transformation occurs slowly, creatures in the area can't usually be trapped or injured by the ground's movement.
 
 At the end of every 10 minutes you spend Concentration on the spell, you can choose a new area of terrain to affect within range.
@@ -4882,7 +4882,7 @@ Source:	Player's Handbook 2024 p. 302</text>
     <range>Touch</range>
     <components>V, S, M (a pinch of diamond dust worth 25+ GP, which the spell consumes)</components>
     <duration>8 hour</duration>
-    <classes>Bard [2024], Ranger [2024], Wizard [2024], Cleric [2024] (Trickery)</classes>
+    <classes>School: Abjuration, Bard [2024], Ranger [2024], Wizard [2024], Cleric [2024] (Trickery)</classes>
     <text>For the duration, you hide a target that you touch from Divination spells. The target can be a willing creature, or it can be a place or an object no larger than 10 feet in any dimension. The target can't be targeted by any Divination spell or perceived through magical scrying sensors.
 
 Source:	Player's Handbook 2024 p. 302</text>
@@ -4895,7 +4895,7 @@ Source:	Player's Handbook 2024 p. 302</text>
     <range>Touch</range>
     <components>V, S, M (a small square of silk)</components>
     <duration>24 hour</duration>
-    <classes>Wizard [2024]</classes>
+    <classes>School: Illusion, Wizard [2024]</classes>
     <text>With a touch, you place an illusion on a willing creature or an object that isn't being worn or carried. A creature gains the Mask effect below, and an object gains the False Aura effect below. The effect lasts for the duration. If you cast the spell on the same target every day for 30 days, the illusion lasts until dispelled.
 
 Mask (Creature). Choose a creature type other than the target's actual type. Spells and other magical effects treat the target as if it were a creature of the chosen type.
@@ -4912,7 +4912,7 @@ Source:	Player's Handbook 2024 p. 302</text>
     <range>300 feet</range>
     <components>V, S, M (a miniature crystal sphere)</components>
     <duration>Instantaneous</duration>
-    <classes>Sorcerer [2024], Wizard [2024]</classes>
+    <classes>School: Evocation, Sorcerer [2024], Wizard [2024]</classes>
     <text>A frigid globe streaks from you to a point of your choice within range, where it explodes in a 60-foot-radius Sphere. Each creature in that area makes a Constitution saving throw, taking 10d6 Cold damage on failed save or half as much damage on a successful one.
 
 If the globe strikes a body of water, it freezes the water to a depth of 6 inches over an area 30 feet square. This ice lasts for 1 minute. Creatures that were swimming on the surface of frozen water are trapped in the ice and have the Restrained condition. A trapped creature can take an action to make a Strength (Athletics) check against your spell save DC to break free.
@@ -4936,7 +4936,7 @@ Source:	Player's Handbook 2024 p. 302</text>
     <range>30 feet</range>
     <components>V, S, M (a glass sphere)</components>
     <duration>Concentration, up to 1 minute</duration>
-    <classes>Wizard [2024]</classes>
+    <classes>School: Abjuration, Wizard [2024]</classes>
     <text>A shimmering sphere encloses a Large or smaller creature or object within range. An unwilling creature must succeed on a Dexterity saving throw or be enclosed for the duration.
 
 Nothing—not physical objects, energy, or other spell effects—can pass through the barrier, in or out, though a creature in the sphere can breathe there. The sphere is immune to all damage, and a creature or object inside can't be damaged by attacks or effects originating from outside, nor can a creature inside the sphere damage anything outside it.
@@ -4955,7 +4955,7 @@ Source:	Player's Handbook 2024 p. 303</text>
     <range>30 feet</range>
     <components>V</components>
     <duration>Concentration, up to 1 minute</duration>
-    <classes>Bard [2024], Wizard [2024]</classes>
+    <classes>School: Enchantment, Bard [2024], Wizard [2024]</classes>
     <text>One creature that you can see within range must make a Wisdom saving throw. On a successful save, the target dances comically until the end of its next turn, during which it must spend all its movement to dance in place.
 
 On a failed save, the target has the Charmed condition for the duration. While Charmed, the target dances comically, must use all its movement to dance in place, and has Disadvantage on Dexterity saving throws and attack rolls, and other creatures have Advantage on attack rolls against it. On each of its turns, the target can take an action to collect itself and repeat the save, ending the spell on itself on a success.
@@ -4970,7 +4970,7 @@ Source:	Player's Handbook 2024 p. 303</text>
     <range>Self</range>
     <components>V, S, M (ashes from burned mistletoe)</components>
     <duration>Concentration, up to 1 hour</duration>
-    <classes>Druid [2024], Ranger [2024], Cleric [2024] (Trickery)</classes>
+    <classes>School: Abjuration, Druid [2024], Ranger [2024], Cleric [2024] (Trickery)</classes>
     <text>You radiate a concealing aura in a 30-foot Emanation for the duration. While in the aura, you and each creature you choose have a +10 bonus to Dexterity (Stealth) checks and leave no tracks.
 
 Source:	Player's Handbook 2024 p. 303</text>
@@ -4983,7 +4983,7 @@ Source:	Player's Handbook 2024 p. 303</text>
     <range>30 feet</range>
     <components>V, S, M (a pinch of sesame seeds)</components>
     <duration>1 hour</duration>
-    <classes>Wizard [2024]</classes>
+    <classes>School: Transmutation, Wizard [2024]</classes>
     <text>A passage appears at a point that you can see on a wooden, plaster, or stone surface (such as a wall, ceiling, or floor) within range and lasts for the duration. You choose the opening's dimensions: up to 5 feet wide, 8 feet tall, and 20 feet deep. The passage creates no instability in a structure surrounding it.
 
 When the opening disappears, any creatures or objects still in the passage created by the spell are safely ejected to an unoccupied space nearest to the surface on which you cast the spell.
@@ -4998,7 +4998,7 @@ Source:	Player's Handbook 2024 p. 303</text>
     <range>60 feet</range>
     <components>V, S, M (a bit of fleece)</components>
     <duration>Concentration, up to 1 minute</duration>
-    <classes>Bard [2024], Sorcerer [2024], Wizard [2024], Warlock [2024] (Archfey), Warlock [2024] (Great Old One)</classes>
+    <classes>School: Illusion, Bard [2024], Sorcerer [2024], Wizard [2024], Warlock [2024] (Archfey), Warlock [2024] (Great Old One)</classes>
     <text>You attempt to craft an illusion in the mind of a creature you can see within range. The target makes an Intelligence saving throw. On a failed save, you create a phantasmal object, creature, or other phenomenon that is no larger than a 10-foot Cube and that is perceivable only to the target for the duration. The phantasm includes sound, temperature, and other stimuli.
 
 The target can take a Study action to examine the phantasm with an Intelligence (Investigation) check against your spell save DC. If the check succeeds, the target realizes that the phantasm is an illusion, and the spell ends.
@@ -5018,7 +5018,7 @@ Source:	Player's Handbook 2024 p. 304</text>
     <range>120 feet</range>
     <components>V, S</components>
     <duration>Concentration, up to 1 minute</duration>
-    <classes>Bard [2024], Wizard [2024]</classes>
+    <classes>School: Illusion, Bard [2024], Wizard [2024]</classes>
     <text>You tap into the nightmares of a creature you can see within range and create an illusion of its deepest fears, visible only to that creature. The target makes a Wisdom saving throw. On a failed save, the target takes 4d10 Psychic damage and has Disadvantage on ability checks and attack rolls for the duration. On a successful save, the target takes half as much damage, and the spell ends.
 
 For the duration, the target makes a Wisdom saving throw at the end of each of its turns. On a failed save, it takes the Psychic damage again. On a successful save, the spell ends.
@@ -5043,7 +5043,7 @@ Source:	Player's Handbook 2024 p. 304</text>
     <range>30 feet</range>
     <components>V, S</components>
     <duration>1 hour</duration>
-    <classes>Wizard [2024]</classes>
+    <classes>School: Illusion, Wizard [2024]</classes>
     <text>A Large, quasi-real, horselike creature appears on the ground in an unoccupied space of your choice within range. You decide the creature's appearance, and it is equipped with a saddle, bit, and bridle. Any of the equipment created by the spell vanishes in a puff of smoke if it is carried more than 10 feet away from the steed.
 
 For the duration, you or a creature you choose can ride the steed. The steed uses the Riding Horse stat block, except it has a Speed of 100 feet and can travel 13 miles in an hour. When the spell ends, the steed gradually fades, giving the rider 1 minute to dismount. The spell ends early if the steed takes any damage.
@@ -5058,7 +5058,7 @@ Source:	Player's Handbook 2024 p. 304</text>
     <range>60 feet</range>
     <components>V, S</components>
     <duration>Instantaneous</duration>
-    <classes>Cleric [2024]</classes>
+    <classes>School: Conjuration, Cleric [2024]</classes>
     <text>You beseech an otherworldly entity for aid. The being must be known to you: a god, a demon prince, or some other being of cosmic power. That entity sends a Celestial, an Elemental, or a Fiend loyal to it to aid you, making the creature appear in an unoccupied space within range. If you know a specific creature's name, you can speak that name when you cast this spell to request that creature, though you might get a different creature anyway (DM's choice).
 
 When the creature appears, it is under no compulsion to behave a particular way. You can ask it to perform a service in exchange for payment, but it isn't obliged to do so. The requested task could range from simple (fly us across the chasm, or help us fight a battle) to complex (spy on our enemies, or protect us during our foray into the dungeon). You must be able to communicate with the creature to bargain for its services.
@@ -5079,7 +5079,7 @@ Source:	Player's Handbook 2024 p. 304</text>
     <range>60 feet</range>
     <components>V, S, M (a jewel worth 1,000+ GP, which the spell consumes)</components>
     <duration>24 hour</duration>
-    <classes>Bard [2024], Cleric [2024], Druid [2024], Warlock [2024], Wizard [2024]</classes>
+    <classes>School: Abjuration, Bard [2024], Cleric [2024], Druid [2024], Warlock [2024], Wizard [2024]</classes>
     <text>You attempt to bind a Celestial, an Elemental, a Fey, or a Fiend to your service. The creature must be within range for the entire casting of the spell. (Typically, the creature is first summoned into the center of the inverted version of the Magic Circle spell to trap it while this spell is cast.) At the completion of the casting, the target must succeed on a Charisma saving throw or be bound to serve you for the duration. If the creature was summoned or created by another spell, that spell's duration is extended to match the duration of this spell.
 
 A bound creature must follow your commands to the best of its ability. You might command the creature to accompany you on an adventure, to guard a location, or to deliver a message. If the creature is Hostile, it strives to twist your commands to achieve its own objectives. If the creature carries out your commands completely before the spell ends, it travels to you to report this fact if you are on the same plane of existence. If you are on a different plane, it returns to the place where you bound it and remains there until the spell ends.
@@ -5097,7 +5097,7 @@ Source:	Player's Handbook 2024 p. 305</text>
     <range>Touch</range>
     <components>V, S, M (a forked, metal rod worth 250+ GP and attuned to a plane of existence)</components>
     <duration>Instantaneous</duration>
-    <classes>Cleric [2024], Druid [2024], Sorcerer [2024], Warlock [2024], Wizard [2024]</classes>
+    <classes>School: Conjuration, Cleric [2024], Druid [2024], Sorcerer [2024], Warlock [2024], Wizard [2024]</classes>
     <text>You and up to eight willing creatures who link hands in a circle are transported to a different plane of existence. You can specify a target destination in general terms, such as the City of Brass on the Elemental Plane of Fire or the palace of Dispater on the second level of the Nine Hells, and you appear in or near that destination, as determined by the DM.
 
 Alternatively, if you know the sigil sequence of a teleportation circle on another plane of existence, this spell can take you to that circle. If the teleportation circle is too small to hold all the creatures you transported, they appear in the closest unoccupied spaces next to the circle.
@@ -5112,7 +5112,7 @@ Source:	Player's Handbook 2024 p. 305</text>
     <range>150 feet</range>
     <components>V, S</components>
     <duration>Instantaneous</duration>
-    <classes>Bard [2024], Druid [2024], Ranger [2024], Paladin [2024] (Ancient), Warlock [2024] (Archfey)</classes>
+    <classes>School: Transmutation, Bard [2024], Druid [2024], Ranger [2024], Paladin [2024] (Ancient), Warlock [2024] (Archfey)</classes>
     <text>This spell channels vitality into plants. The casting time you use determines whether the spell has the Overgrowth or the Enrichment effect below.
 
 Overgrowth:
@@ -5131,7 +5131,7 @@ Source:	Player's Handbook 2024 p. 305</text>
     <range>30 feet</range>
     <components>V, S</components>
     <duration>Instantaneous</duration>
-    <classes>Druid [2024], Sorcerer [2024], Warlock [2024], Wizard [2024]</classes>
+    <classes>School: Necromancy, Druid [2024], Sorcerer [2024], Warlock [2024], Wizard [2024]</classes>
     <text>You spray toxic mist at a creature within range. Make a ranged spell attack against the target. On a hit, the target takes 1d12 Poison damage.
 
 Cantrip Upgrade: The damage increases by 1d12 when you reach levels 5 (2d12), 11 (3d12), and 17 (4d12).
@@ -5150,7 +5150,7 @@ Source:	Player's Handbook 2024 p. 306</text>
     <range>60 feet</range>
     <components>V, S, M (a caterpillar cocoon)</components>
     <duration>Concentration, up to 1 hour</duration>
-    <classes>Bard [2024], Druid [2024], Sorcerer [2024], Wizard [2024], Druid [2024] (Tropical Land)</classes>
+    <classes>School: Transmutation, Bard [2024], Druid [2024], Sorcerer [2024], Wizard [2024], Druid [2024] (Tropical Land)</classes>
     <text>You attempt to transform a creature that you can see within range into a Beast. The target must succeed on a Wisdom saving throw or shape-shift into Beast form for the duration. That form can be any Beast you choose that has a Challenge Rating equal to or less than the target's (or the target's level if it doesn't have a Challenge Rating). The target's game statistics are replaced by the stat block of the chosen Beast, but the target retains its alignment, personality, creature type, Hit Points, and Hit Point Dice.
 
 The target gains a number of Temporary Hit Points equal to the Hit Points of the Beast form. The spell ends early on the target if it has no Temporary Hit Points left. These Temporary Hit Points vanish if any remain when the spell ends.
@@ -5169,7 +5169,7 @@ Source:	Player's Handbook 2024 p. 306</text>
     <range>60 feet</range>
     <components>V</components>
     <duration>Instantaneous</duration>
-    <classes>Bard [2024], Cleric [2024]</classes>
+    <classes>School: Enchantment, Bard [2024], Cleric [2024]</classes>
     <text>You fortify up to six creatures you can see within range. The spell bestows 120 Temporary Hit Points, which you divide among the spell's recipients.
 
 Source:	Player's Handbook 2024 p. 306</text>
@@ -5182,7 +5182,7 @@ Source:	Player's Handbook 2024 p. 306</text>
     <range>Touch</range>
     <components>V, S</components>
     <duration>Instantaneous</duration>
-    <classes>Bard [2024], Cleric [2024]</classes>
+    <classes>School: Enchantment, Bard [2024], Cleric [2024]</classes>
     <text>A wave of healing energy washes over one creature you can see within range. The target regains all its Hit Points. If the creature has the Charmed, Frightened, Paralyzed, Poisoned, or Stunned condition, the condition ends. If the creature has the Prone condition, it can use its Reaction to stand up.
 
 Source:	Player's Handbook 2024 p. 306</text>
@@ -5195,7 +5195,7 @@ Source:	Player's Handbook 2024 p. 306</text>
     <range>60 feet</range>
     <components>V</components>
     <duration>Instantaneous</duration>
-    <classes>Bard [2024], Sorcerer [2024], Warlock [2024], Wizard [2024]</classes>
+    <classes>School: Enchantment, Bard [2024], Sorcerer [2024], Warlock [2024], Wizard [2024]</classes>
     <text>You compel one creature you can see within range to die. If the target has 100 Hit Points or fewer, it dies. Otherwise, it takes 12d12 Psychic damage.
 
 Source:	Player's Handbook 2024 p. 306</text>
@@ -5209,7 +5209,7 @@ Source:	Player's Handbook 2024 p. 306</text>
     <range>60 feet</range>
     <components>V</components>
     <duration>Instantaneous</duration>
-    <classes>Bard [2024], Sorcerer [2024], Warlock [2024], Wizard [2024]</classes>
+    <classes>School: Enchantment, Bard [2024], Sorcerer [2024], Warlock [2024], Wizard [2024]</classes>
     <text>You overwhelm the mind of one creature you can see within range. If the target has 150 Hit Points or fewer, it has the Stunned condition. Otherwise, its Speed is 0 until the start of your next turn.
 
 The Stunned target makes a Constitution saving throw at the end of each of its turns, ending the condition on itself on a success.
@@ -5224,7 +5224,7 @@ Source:	Player's Handbook 2024 p. 306</text>
     <range>30 feet</range>
     <components>V</components>
     <duration>Instantaneous</duration>
-    <classes>Cleric [2024], Paladin [2024]</classes>
+    <classes>School: Abjuration, Cleric [2024], Paladin [2024]</classes>
     <text>Up to five creatures of your choice who remain within range for the spell's entire casting gain the benefits of a Short Rest and also regain 2d8 Hit Points. A creature can't be affected by this spell again until that creature finishes a Long Rest.
 
 Using a Higher-Level Spell Slot:
@@ -5248,7 +5248,7 @@ Source:	Player's Handbook 2024 p. 307</text>
     <range>10 feet</range>
     <components>V, S</components>
     <duration>1 hour</duration>
-    <classes>Bard [2024], Sorcerer [2024], Warlock [2024], Wizard [2024]</classes>
+    <classes>School: Transmutation, Bard [2024], Sorcerer [2024], Warlock [2024], Wizard [2024]</classes>
     <text>You create a magical effect within range. Choose the effect from the options below. If you cast this spell multiple times, you can have up to three of its non-instantaneous effects active at a time.
 
 Sensory Effect:
@@ -5279,7 +5279,7 @@ Source:	Player's Handbook 2024 p. 307</text>
     <range>60 feet</range>
     <components>V, S</components>
     <duration>Instantaneous</duration>
-    <classes>Bard [2024], Sorcerer [2024], Wizard [2024]</classes>
+    <classes>School: Evocation, Bard [2024], Sorcerer [2024], Wizard [2024]</classes>
     <text>Eight rays of light flash from you in a 60-foot Cone. Each creature in the Cone makes a Dexterity saving throw. For each target, roll 1d8 to determine which color ray affects it, consulting the Prismatic Rays table.
 
 1d8 | Ray
@@ -5304,7 +5304,7 @@ Source:	Player's Handbook 2024 p. 307</text>
     <range>60 feet</range>
     <components>V, S</components>
     <duration>10 minute</duration>
-    <classes>Bard [2024], Wizard [2024]</classes>
+    <classes>School: Abjuration, Bard [2024], Wizard [2024]</classes>
     <text>A shimmering, multicolored plane of light forms a vertical opaque wall—up to 90 feet long, 30 feet high, and 1 inch thick—centered on a point within range. Alternatively, you shape the wall into a globe up to 30 feet in diameter centered on a point within range. The wall lasts for the duration. If you position the wall in a space occupied by a creature, the spell ends instantly without effect.
 
 The wall sheds Bright Light within 100 feet and Dim Light for an additional 100 feet. You and creatures you designate when you cast the spell can pass through and be near the wall without harm. If another creature that can see the wall moves within 20 feet of it or starts its turn there, the creature must succeed on a Constitution saving throw or have the Blinded condition for 1 minute.
@@ -5333,7 +5333,7 @@ Source:	Player's Handbook 2024 p. 308</text>
     <range>Self</range>
     <components>V, S</components>
     <duration>10 minute</duration>
-    <classes>Druid [2024]</classes>
+    <classes>School: Conjuration, Druid [2024]</classes>
     <text>A flickering flame appears in your hand and remains there for the duration. While there, the flame emits no heat and ignites nothing, and it sheds Bright Light in a 20-foot radius and Dim Light for an additional 20 feet. The spell ends if you cast it again.
 
 Until the spell ends, you can take a Magic action to hurl fire at a creature or an object within 60 feet of you. Make a ranged spell attack. On a hit, the target takes 1d8 Fire damage.
@@ -5354,7 +5354,7 @@ Source:	Player's Handbook 2024 p. 308</text>
     <range>120 feet</range>
     <components>V, S, M (jade dust worth 25+ GP)</components>
     <duration/>
-    <classes>Bard [2024], Wizard [2024]</classes>
+    <classes>School: Illusion, Bard [2024], Wizard [2024]</classes>
     <text>You create an illusion of an object, a creature, or some other visible phenomenon within range that activates when a specific trigger occurs. The illusion is imperceptible until then. It must be no larger than a 30-foot Cube, and you decide when you cast the spell how the illusion behaves and what sounds it makes. This scripted performance can last up to 5 minutes.
 
 When the trigger you specify occurs, the illusion springs into existence and performs in the manner you described. Once the illusion finishes performing, it disappears and remains dormant for 10 minutes, after which the illusion can be activated again.
@@ -5373,7 +5373,7 @@ Source:	Player's Handbook 2024 p. 309</text>
     <range>500 Miles</range>
     <components>V, S, M (a statuette of yourself worth 5+ GP)</components>
     <duration>Concentration, up to 1 day</duration>
-    <classes>Bard [2024], Wizard [2024]</classes>
+    <classes>School: Illusion, Bard [2024], Wizard [2024]</classes>
     <text>You create an illusory copy of yourself that lasts for the duration. The copy can appear at any location within range that you have seen before, regardless of intervening obstacles. The illusion looks and sounds like you, but it is intangible. If the illusion takes any damage, it disappears, and the spell ends.
 
 You can see through the illusion's eyes and hear through its ears as if you were in its space. As a Magic action, you can move it up to 60 feet and make it gesture, speak, and behave in whatever way you choose. It mimics your mannerisms perfectly.
@@ -5390,7 +5390,7 @@ Source:	Player's Handbook 2024 p. 309</text>
     <range>Touch</range>
     <components>V, S</components>
     <duration>Concentration, up to 1 hour</duration>
-    <classes>Cleric [2024], Druid [2024], Ranger [2024], Sorcerer [2024], Wizard [2024], Paladin [2024] (Glory), Paladin [2024] (Ancient), Paladin [2024] (Vengeance), Sorcerer [2024] (Clockwork)</classes>
+    <classes>School: Abjuration, Cleric [2024], Druid [2024], Ranger [2024], Sorcerer [2024], Wizard [2024], Paladin [2024] (Glory), Paladin [2024] (Ancient), Paladin [2024] (Vengeance), Sorcerer [2024] (Clockwork)</classes>
     <text>For the duration, the willing creature you touch has Resistance to one damage type of your choice: Acid, Cold, Fire, Lightning, or Thunder.
 
 Source:	Player's Handbook 2024 p. 309</text>
@@ -5403,7 +5403,7 @@ Source:	Player's Handbook 2024 p. 309</text>
     <range>Touch</range>
     <components>V, S, M (a flask of Holy Water worth 25+ GP, which the spell consumes)</components>
     <duration>Concentration, up to 10 minute</duration>
-    <classes>Cleric [2024], Druid [2024], Warlock [2024], Wizard [2024], Paladin [2024], Paladin [2024] (Devotion), Sorcerer [2024] (Clockwork)</classes>
+    <classes>School: Abjuration, Cleric [2024], Druid [2024], Warlock [2024], Wizard [2024], Paladin [2024], Paladin [2024] (Devotion), Sorcerer [2024] (Clockwork)</classes>
     <text>Until the spell ends, one willing creature you touch is protected against creatures that are Aberrations, Celestials, Elementals, Fey, Fiends, or Undead. The protection grants several benefits. Creatures of those types have Disadvantage on attack rolls against the target. The target also can't be possessed by or gain the Charmed or Frightened conditions from them. If the target is already possessed, Charmed, or Frightened by such a creature, the target has Advantage on any new saving throw against the relevant effect.
 
 Source:	Player's Handbook 2024 p. 309</text>
@@ -5416,7 +5416,7 @@ Source:	Player's Handbook 2024 p. 309</text>
     <range>Touch</range>
     <components>V, S</components>
     <duration>1 hour</duration>
-    <classes>Cleric [2024], Druid [2024], Ranger [2024], Paladin [2024]</classes>
+    <classes>School: Abjuration, Cleric [2024], Druid [2024], Ranger [2024], Paladin [2024]</classes>
     <text>You touch a creature and end the Poisoned condition on it. For the duration, the target has Advantage on saving throws to avoid or end the Poisoned condition, and it has Resistance to Poison damage.
 
 Source:	Player's Handbook 2024 p. 310</text>
@@ -5430,7 +5430,7 @@ Source:	Player's Handbook 2024 p. 310</text>
     <range>10 feet</range>
     <components>V, S</components>
     <duration>Instantaneous</duration>
-    <classes>Cleric [2024], Druid [2024], Paladin [2024]</classes>
+    <classes>School: Transmutation, Cleric [2024], Druid [2024], Paladin [2024]</classes>
     <text>You remove poison and rot from nonmagical food and drink in a 5-foot-radius Sphere centered on a point within range.
 
 Source:	Player's Handbook 2024 p. 310</text>
@@ -5443,7 +5443,7 @@ Source:	Player's Handbook 2024 p. 310</text>
     <range>Touch</range>
     <components>V, S, M (a diamond worth 500+ GP, which the spell consumes)</components>
     <duration>Instantaneous</duration>
-    <classes>Bard [2024], Cleric [2024], Paladin [2024]</classes>
+    <classes>School: Necromancy, Bard [2024], Cleric [2024], Paladin [2024]</classes>
     <text>With a touch, you revive a dead creature if it has been dead no longer than 10 days and it wasn't Undead when it died.
 
 The creature returns to life with 1 Hit Points. This spell also neutralizes any poisons that affected the creature at the time of death.
@@ -5463,7 +5463,7 @@ Source:	Player's Handbook 2024 p. 310</text>
     <range>30 feet</range>
     <components>V, S, M (two eggs)</components>
     <duration>1 hour</duration>
-    <classes>Bard [2024], Wizard [2024], Sorcerer [2024] (Aberrant)</classes>
+    <classes>School: Divination, Bard [2024], Wizard [2024], Sorcerer [2024] (Aberrant)</classes>
     <text>You forge a telepathic link among up to eight willing creatures of your choice within range, psychically linking each creature to all the others for the duration. Creatures that can't communicate in any languages aren't affected by this spell.
 
 Until the spell ends, the targets can communicate telepathically through the bond whether or not they share a language. The communication is possible over any distance, though it can't extend to other planes of existence.
@@ -5478,7 +5478,7 @@ Source:	Player's Handbook 2024 p. 311</text>
     <range>60 feet</range>
     <components>V, S</components>
     <duration>Concentration, up to 1 minute</duration>
-    <classes>Warlock [2024], Wizard [2024]</classes>
+    <classes>School: Necromancy, Warlock [2024], Wizard [2024]</classes>
     <text>A beam of enervating energy shoots from you toward a creature within range. The target must make a Constitution saving throw. On a successful save, the target has Disadvantage on the next attack roll it makes until the start of your next turn.
 
 On a failed save, the target has Disadvantage on Strength-based D20 Tests for the duration. During that time, it also subtracts 1d8 from all its damage rolls. The target repeats the save at the end of each of its turns, ending the spell on a success.
@@ -5494,7 +5494,7 @@ Source:	Player's Handbook 2024 p. 311</text>
     <range>60 feet</range>
     <components>V, S</components>
     <duration>Instantaneous</duration>
-    <classes>Sorcerer [2024], Wizard [2024], Druid [2024] (Polar Land), Druid [2024] (Sea)</classes>
+    <classes>School: Evocation, Sorcerer [2024], Wizard [2024], Druid [2024] (Polar Land), Druid [2024] (Sea)</classes>
     <text>A frigid beam of blue-white light streaks toward a creature within range. Make a ranged spell attack against the target. On a hit, it takes 1d8 Cold damage, and its Speed is reduced by 10 feet until the start of your next turn.
 
 Cantrip Upgrade: The damage increases by 1d8 when you reach levels 5 (2d8), 11 (3d8), and 17 (4d8).
@@ -5513,7 +5513,7 @@ Source:	Player's Handbook 2024 p. 311</text>
     <range>60 feet</range>
     <components>V, S</components>
     <duration>Instantaneous</duration>
-    <classes>Sorcerer [2024], Wizard [2024], Druid [2024] (Tropical Land)</classes>
+    <classes>School: Necromancy, Sorcerer [2024], Wizard [2024], Druid [2024] (Tropical Land)</classes>
     <text>You shoot a greenish ray at a creature within range. Make a ranged spell attack against the target. On a hit, the target takes 2d8 Poison damage and has the Poisoned condition until the end of your next turn.
 
 Using a Higher-Level Spell Slot:
@@ -5538,7 +5538,7 @@ Source:	Player's Handbook 2024 p. 311</text>
     <range>Touch</range>
     <components>V, S, M (a prayer wheel)</components>
     <duration>1 hour</duration>
-    <classes>Bard [2024], Cleric [2024], Druid [2024]</classes>
+    <classes>School: Transmutation, Bard [2024], Cleric [2024], Druid [2024]</classes>
     <text>A creature you touch regains 4d8 + 15 Hit Points. For the duration, the target regains 1 Hit Point at the start of each of its turns, and any severed body parts regrow after 2 minutes.
 
 Source:	Player's Handbook 2024 p. 311</text>
@@ -5552,7 +5552,7 @@ Source:	Player's Handbook 2024 p. 311</text>
     <range>Touch</range>
     <components>V, S, M (rare oils worth 1,000+ GP, which the spell consumes)</components>
     <duration>Instantaneous</duration>
-    <classes>Druid [2024]</classes>
+    <classes>School: Necromancy, Druid [2024]</classes>
     <text>You touch a dead Humanoid or a piece of one. If the creature has been dead no longer than 10 days, the spell forms a new body for it and calls the soul to enter that body. Roll 1d10 and consult the table below to determine the body's species, or the DM chooses another playable species.
 
 1d10 | Species
@@ -5578,7 +5578,7 @@ Source:	Player's Handbook 2024 p. 311</text>
     <range>Touch</range>
     <components>V, S</components>
     <duration>Instantaneous</duration>
-    <classes>Cleric [2024], Warlock [2024], Wizard [2024], Paladin [2024]</classes>
+    <classes>School: Abjuration, Cleric [2024], Warlock [2024], Wizard [2024], Paladin [2024]</classes>
     <text>At your touch, all curses affecting one creature or object end. If the object is a cursed magic item, its curse remains, but the spell breaks its owner's Attunement to the object so it can be removed or discarded.
 
 Source:	Player's Handbook 2024 p. 312</text>
@@ -5591,7 +5591,7 @@ Source:	Player's Handbook 2024 p. 312</text>
     <range>Touch</range>
     <components>V, S</components>
     <duration>Concentration, up to 1 minute</duration>
-    <classes>Cleric [2024], Druid [2024]</classes>
+    <classes>School: Abjuration, Cleric [2024], Druid [2024]</classes>
     <text>You touch a willing creature and choose a damage type: Acid, Bludgeoning, Cold, Fire, Lightning, Necrotic, Piercing, Poison, Radiant, Slashing, or Thunder. When the creature takes damage of the chosen type before the spell ends, the creature reduces the total damage taken by 1d4. A creature can benefit from this spell only once per turn.
 
 Source:	Player's Handbook 2024 p. 312</text>
@@ -5604,7 +5604,7 @@ Source:	Player's Handbook 2024 p. 312</text>
     <range>Touch</range>
     <components>V, S, M (a diamond worth 1,000+ GP, which the spell consumes)</components>
     <duration>Instantaneous</duration>
-    <classes>Bard [2024], Cleric [2024]</classes>
+    <classes>School: Necromancy, Bard [2024], Cleric [2024]</classes>
     <text>With a touch, you revive a dead creature that has been dead for no more than a century, didn't die of old age, and wasn't Undead when it died.
 
 The creature returns to life with all its Hit Points. This spell also neutralizes any poisons that affected the creature at the time of death. This spell closes all mortal wounds and restores any missing body parts.
@@ -5623,7 +5623,7 @@ Source:	Player's Handbook 2024 p. 312</text>
     <range>100 feet</range>
     <components>V, S, M (a lodestone and iron filings)</components>
     <duration>Concentration, up to 1 minute</duration>
-    <classes>Druid [2024], Sorcerer [2024], Wizard [2024]</classes>
+    <classes>School: Transmutation, Druid [2024], Sorcerer [2024], Wizard [2024]</classes>
     <text>This spell reverses gravity in a 50-foot-radius, 100-foot high Cylinder centered on a point within range. All creatures and objects in that area that aren't anchored to the ground fall upward and reach the top of the Cylinder. A creature can make a Dexterity saving throw to grab a fixed object it can reach, thus avoiding the fall upward.
 
 If a ceiling or an anchored object is encountered in this upward fall, creatures and objects strike it just as they would during a downward fall. If an affected creature or object reaches the Cylinder's top without striking anything, it hovers there for the duration. When the spell ends, affected objects and creatures fall downward.
@@ -5638,7 +5638,7 @@ Source:	Player's Handbook 2024 p. 312</text>
     <range>Touch</range>
     <components>V, S, M (a diamond worth 300+ GP, which the spell consumes)</components>
     <duration>Instantaneous</duration>
-    <classes>Cleric [2024], Druid [2024], Ranger [2024], Paladin [2024], Cleric [2024] (Life), Warlock [2024] (Celestial), Cleric (Grave)</classes>
+    <classes>School: Necromancy, Cleric [2024], Druid [2024], Ranger [2024], Paladin [2024], Cleric [2024] (Life), Warlock [2024] (Celestial), Cleric (Grave)</classes>
     <text>You touch a creature that has died within the last minute. That creature revives with 1 Hit Points. This spell can't revive a creature that has died of old age, nor does it restore any missing body parts.
 
 Source:	Player's Handbook 2024 p. 312</text>
@@ -5651,7 +5651,7 @@ Source:	Player's Handbook 2024 p. 312</text>
     <range>Touch</range>
     <components>V, S, M (a segment of rope)</components>
     <duration>1 hour</duration>
-    <classes>Wizard [2024], Ranger [2024] (Gloomstalker)</classes>
+    <classes>School: Transmutation, Wizard [2024], Ranger [2024] (Gloomstalker)</classes>
     <text>You touch a rope. One end of it hovers upward until the rope hangs perpendicular to the ground or the rope reaches a ceiling. At the rope's upper end, an Invisible 3-foot-by-5-foot portal opens to an extradimensional space that lasts until the spell ends. That space can be reached by climbing the rope, which can be pulled into or dropped out of it.
 
 The space can hold up to eight Medium or smaller creatures. Attacks, spells, and other effects can't pass into or out of the space, but creatures inside it can see through the portal. Anything inside the space drops out when the spell ends.
@@ -5666,7 +5666,7 @@ Source:	Player's Handbook 2024 p. 312</text>
     <range>60 feet</range>
     <components>V, S</components>
     <duration>Instantaneous</duration>
-    <classes>Cleric [2024], Warlock [2024] (Celestial)</classes>
+    <classes>School: Evocation, Cleric [2024], Warlock [2024] (Celestial)</classes>
     <text>Flame-like radiance descends on a creature that you can see within range. The target must succeed on a Dexterity saving throw or take 1d8 Radiant damage. The target gains no benefit from Half Cover or Three-Quarters Cover for this save.
 
 Cantrip Upgrade: The damage increases by 1d8 when you reach levels 5 (2d8), 11 (3d8), and 17 (4d8).
@@ -5685,7 +5685,7 @@ Source:	Player's Handbook 2024 p. 313</text>
     <range>30 feet</range>
     <components>V, S, M (a shard of glass from a mirror)</components>
     <duration>1 minute</duration>
-    <classes>Cleric [2024]</classes>
+    <classes>School: Abjuration, Cleric [2024]</classes>
     <text>You ward a creature within range. Until the spell ends, any creature who targets the warded creature with an attack roll or a damaging spell must succeed on a Wisdom saving throw or either choose a new target or lose the attack or spell. This spell doesn't protect the warded creature from areas of effect.
 
 The spell ends if the warded creature makes an attack roll, casts a spell, or deals damage.
@@ -5700,7 +5700,7 @@ Source:	Player's Handbook 2024 p. 313</text>
     <range>120 feet</range>
     <components>V, S</components>
     <duration>Instantaneous</duration>
-    <classes>Sorcerer [2024], Wizard [2024], Cleric [2024] (Light), Warlock [2024] (Fiend)</classes>
+    <classes>School: Evocation, Sorcerer [2024], Wizard [2024], Cleric [2024] (Light), Warlock [2024] (Fiend)</classes>
     <text>You hurl three fiery rays. You can hurl them at one target within range or at several. Make a ranged spell attack for each ray. On a hit, the target takes 2d6 Fire damage.
 
 Using a Higher-Level Spell Slot:
@@ -5717,7 +5717,7 @@ Source:	Player's Handbook 2024 p. 314</text>
     <range>Self</range>
     <components>V, S, M (a focus worth 1,000+ GP, such as a crystal ball, mirror, or water-filled font)</components>
     <duration>Concentration, up to 10 minute</duration>
-    <classes>Bard [2024], Cleric [2024], Druid [2024], Warlock [2024], Wizard [2024], Cleric [2024] (Light), Paladin [2024] (Vengeance)</classes>
+    <classes>School: Divination, Bard [2024], Cleric [2024], Druid [2024], Warlock [2024], Wizard [2024], Cleric [2024] (Light), Paladin [2024] (Vengeance)</classes>
     <text>You can see and hear a creature you choose that is on the same plane of existence as you. The target makes a Wisdom saving throw, which is modified (see the tables below) by how well you know the target and the sort of physical connection you have to it. The target doesn't know what it is making the save against, only that it feels uneasy.
 
 Your Knowledge of the Target Is... | Save Modifier
@@ -5740,7 +5740,7 @@ Source:	Player's Handbook 2024 p. 314</text>
     <range>Self</range>
     <components>V</components>
     <duration>1 minute</duration>
-    <classes>Paladin [2024]</classes>
+    <classes>School: Evocation, Paladin [2024]</classes>
     <text>As you hit the target, it takes an extra 1d6 Fire damage from the attack. At the start of each of its turns until the spell ends, the target takes 1d6 Fire damage and then makes a Constitution saving throw. On a failed save, the spell continues. On a successful save, the spell ends.
 
 Using a Higher-Level Spell Slot:
@@ -5765,7 +5765,7 @@ Source:	Player's Handbook 2024 p. 314</text>
     <range>Self</range>
     <components>V, S, M (a pinch of talc)</components>
     <duration>1 hour</duration>
-    <classes>Bard [2024], Sorcerer [2024], Wizard [2024], Cleric [2024] (Light)</classes>
+    <classes>School: Divination, Bard [2024], Sorcerer [2024], Wizard [2024], Cleric [2024] (Light)</classes>
     <text>For the duration, you see creatures and objects that have the Invisible condition as if they were visible, and you can see into the Ethereal Plane. Creatures and objects there appear ghostly.
 
 Source:	Player's Handbook 2024 p. 314</text>
@@ -5778,7 +5778,7 @@ Source:	Player's Handbook 2024 p. 314</text>
     <range>30 feet</range>
     <components>V, S</components>
     <duration>8 hour</duration>
-    <classes>Bard [2024], Sorcerer [2024], Wizard [2024], Ranger [2024] (Gloomstalker), Warlock [2024] (Archfey)</classes>
+    <classes>School: Illusion, Bard [2024], Sorcerer [2024], Wizard [2024], Ranger [2024] (Gloomstalker), Warlock [2024] (Archfey)</classes>
     <text>You give an illusory appearance to each creature of your choice that you can see within range. An unwilling target can make a Charisma saving throw, and if it succeeds, it is unaffected by this spell.
 
 You can give the same appearance or different ones to the targets. The spell can change the appearance of the targets' bodies and equipment. You can make each creature seem 1 foot shorter or taller and appear heavier or lighter. A target's new appearance must have the same basic arrangement of limbs as the target, but the extent of the illusion is otherwise up to you. The spell lasts for the duration.
@@ -5797,7 +5797,7 @@ Source:	Player's Handbook 2024 p. 314</text>
     <range>Unlimited</range>
     <components>V, S, M (a copper wire)</components>
     <duration>Instantaneous</duration>
-    <classes>Bard [2024], Cleric [2024], Wizard [2024], Sorcerer [2024] (Aberrant)</classes>
+    <classes>School: Divination, Bard [2024], Cleric [2024], Wizard [2024], Sorcerer [2024] (Aberrant)</classes>
     <text>You send a short message of 25 words or fewer to a creature you have met or a creature described to you by someone who has met it. The target hears the message in its mind, recognizes you as the sender if it knows you, and can answer in a like manner immediately. The spell enables targets to understand the meaning of your message.
 
 You can send the message across any distance and even to other planes of existence, but if the target is on a different plane than you, there is a 5 chance that the message doesn't arrive. You know if the delivery fails.
@@ -5814,7 +5814,7 @@ Source:	Player's Handbook 2024 p. 314</text>
     <range>Touch</range>
     <components>V, S, M (gem dust worth 5,000+ GP, which the spell consumes)</components>
     <duration/>
-    <classes>Wizard [2024]</classes>
+    <classes>School: Transmutation, Wizard [2024]</classes>
     <text>With a touch, you magically sequester an object or a willing creature. For the duration, the target has the Invisible condition and can't be targeted by Divination spells, detected by magic, or viewed remotely with magic.
 
 If the target is a creature, it enters a state of suspended animation; it has the Unconscious condition, doesn't age, and doesn't need food, water, or air.
@@ -5835,7 +5835,7 @@ Source:	Player's Handbook 2024 p. 315</text>
     <range>Self</range>
     <components>V, S, M (a jade circlet worth 1,500+ GP)</components>
     <duration>Concentration, up to 1 hour</duration>
-    <classes>Druid [2024], Wizard [2024]</classes>
+    <classes>School: Transmutation, Druid [2024], Wizard [2024]</classes>
     <text>You shape-shift into another creature for the duration or until you take a Magic action to shape-shift into a different eligible form. The new form must be of a creature that has a Challenge Rating no higher than your level or Challenge Rating. You must have seen the sort of creature before, and it can't be a Construct or an Undead.
 
 When you cast the spell, you gain a number of Temporary Hit Points equal to the Hit Points of the first form into which you shape-shift. These Temporary Hit Points vanish if any remain when the spell ends.
@@ -5854,7 +5854,7 @@ Source:	Player's Handbook 2024 p. 315</text>
     <range>60 feet</range>
     <components>V, S, M (a chip of mica)</components>
     <duration>Instantaneous</duration>
-    <classes>Bard [2024], Sorcerer [2024], Wizard [2024], Druid [2024] (Sea)</classes>
+    <classes>School: Evocation, Bard [2024], Sorcerer [2024], Wizard [2024], Druid [2024] (Sea)</classes>
     <text>A loud noise erupts from a point of your choice within range. Each creature in a 10-foot-radius Sphere centered there makes a Constitution saving throw, taking 3d8 Thunder damage on a failed save or half as much damage on a successful one. A Construct has Disadvantage on the save.
 
 A nonmagical object that isn't being worn or carried also takes the damage if it's in the spell's area.
@@ -5880,7 +5880,7 @@ Source:	Player's Handbook 2024 p. 316</text>
     <range>Self</range>
     <components>V, S</components>
     <duration>1 round</duration>
-    <classes>Sorcerer [2024], Wizard [2024]</classes>
+    <classes>School: Abjuration, Sorcerer [2024], Wizard [2024]</classes>
     <text>An imperceptible barrier of magical force protects you. Until the start of your next turn, you have a +5 bonus to AC, including against the triggering attack, and you take no damage from Magic Missile.
 
 Source:	Player's Handbook 2024 p. 316</text>
@@ -5893,7 +5893,7 @@ Source:	Player's Handbook 2024 p. 316</text>
     <range>60 feet</range>
     <components>V, S, M (a prayer scroll)</components>
     <duration>Concentration, up to 10 minute</duration>
-    <classes>Cleric [2024], Paladin [2024], Cleric [2024] (War), Paladin [2024] (Devotion)</classes>
+    <classes>School: Abjuration, Cleric [2024], Paladin [2024], Cleric [2024] (War), Paladin [2024] (Devotion)</classes>
     <text>A shimmering field surrounds a creature of your choice within range, granting it a +2 bonus to AC for the duration.
 
 Source:	Player's Handbook 2024 p. 316</text>
@@ -5906,7 +5906,7 @@ Source:	Player's Handbook 2024 p. 316</text>
     <range>Touch</range>
     <components>V, S, M (mistletoe)</components>
     <duration>1 minute</duration>
-    <classes>Druid [2024]</classes>
+    <classes>School: Transmutation, Druid [2024]</classes>
     <text>A Club or Quarterstaff you are holding is imbued with nature's power. For the duration, you can use your spellcasting ability instead of Strength for the attack and damage rolls of melee attacks using that weapon, and the weapon's damage die becomes a d8. If the attack deals damage, it can be Force damage or the weapon's normal damage type (your choice).
 
 The spell ends early if you cast it again or if you let go of the weapon.
@@ -5923,7 +5923,7 @@ Source:	Player's Handbook 2024 p. 316</text>
     <range>Self</range>
     <components>V</components>
     <duration>Concentration, up to 1 minute</duration>
-    <classes>Paladin [2024]</classes>
+    <classes>School: Transmutation, Paladin [2024]</classes>
     <text>The target hit by the strike takes an extra 2d6 Radiant damage from the attack. Until the spell ends, the target sheds Bright Light in a 5-foot radius, attack rolls against it have Advantage, and it can't benefit from the Invisible condition.
 
 Using a Higher-Level Spell Slot:
@@ -5947,7 +5947,7 @@ Source:	Player's Handbook 2024 p. 316</text>
     <range>Touch</range>
     <components>V, S</components>
     <duration>Instantaneous</duration>
-    <classes>Sorcerer [2024], Wizard [2024], Druid [2024] (Temperate Land)</classes>
+    <classes>School: Evocation, Sorcerer [2024], Wizard [2024], Druid [2024] (Temperate Land)</classes>
     <text>Lightning springs from you to a creature that you try to touch. Make a melee spell attack against the target. On a hit, the target takes 1d8 Lightning damage, and it can't make Opportunity Attacks until the start of its next turn.
 
 Cantrip Upgrade: The damage increases by 1d8 when you reach levels 5 (2d8), 11 (3d8), and 17 (4d8).
@@ -5967,7 +5967,7 @@ Source:	Player's Handbook 2024 p. 316</text>
     <range>120 feet</range>
     <components>V, S</components>
     <duration>Concentration, up to 10 minute</duration>
-    <classes>Bard [2024], Cleric [2024], Ranger [2024]</classes>
+    <classes>School: Illusion, Bard [2024], Cleric [2024], Ranger [2024]</classes>
     <text>For the duration, no sound can be created within or pass through a 20-foot-radius Sphere centered on a point you choose within range. Any creature or object entirely inside the Sphere has Immunity to Thunder damage, and creatures have the Deafened condition while entirely inside it. Casting a spell that includes a Verbal component is impossible there.
 
 Source:	Player's Handbook 2024 p. 316</text>
@@ -5980,7 +5980,7 @@ Source:	Player's Handbook 2024 p. 316</text>
     <range>60 feet</range>
     <components>V, S, M (a bit of fleece)</components>
     <duration>Concentration, up to 10 minute</duration>
-    <classes>Bard [2024], Sorcerer [2024], Wizard [2024]</classes>
+    <classes>School: Illusion, Bard [2024], Sorcerer [2024], Wizard [2024]</classes>
     <text>You create the image of an object, a creature, or some other visible phenomenon that is no larger than a 15-foot Cube. The image appears at a spot within range and lasts for the duration. The image is purely visual; it isn't accompanied by sound, smell, or other sensory effects.
 
 As a Magic action, you can cause the image to move to any spot within range. As the image changes location, you can alter its appearance so that its movements appear natural for the image. For example, if you create an image of a creature and move it, you can alter the image so that it appears to be walking.
@@ -5997,7 +5997,7 @@ Source:	Player's Handbook 2024 p. 317</text>
     <range>Touch</range>
     <components>V, S, M (powdered ruby worth 1,500+ GP, which the spell consumes)</components>
     <duration/>
-    <classes>Wizard [2024]</classes>
+    <classes>School: Illusion, Wizard [2024]</classes>
     <text>You create a simulacrum of one Beast or Humanoid that is within 10 feet of you for the entire casting of the spell. You finish the casting by touching both the creature and a pile of ice or snow that is the same size as that creature, and the pile turns into the simulacrum, which is a creature. It uses the game statistics of the original creature at the time of casting, except it is a Construct, its Hit Points maximum is half as much, and it can't cast this spell.
 
 The simulacrum is Friendly to you and creatures you designate. It obeys your commands and acts on your turn in combat. The simulacrum can't gain levels, and it can't take Short or Long Rests.
@@ -6016,7 +6016,7 @@ Source:	Player's Handbook 2024 p. 317</text>
     <range>60 feet</range>
     <components>V, S, M (a pinch of sand or rose petals)</components>
     <duration>Concentration, up to 1 minute</duration>
-    <classes>Bard [2024], Sorcerer [2024], Wizard [2024], Druid [2024] (Temperate Land), Warlock [2024] (Archfey)</classes>
+    <classes>School: Enchantment, Bard [2024], Sorcerer [2024], Wizard [2024], Druid [2024] (Temperate Land), Warlock [2024] (Archfey)</classes>
     <text>Each creature of your choice in a 5-foot-radius Sphere centered on a point within range must succeed on a Wisdom saving throw or have the Incapacitated condition until the end of its next turn, at which point it must repeat the save. If the target fails the second save, the target has the Unconscious condition for the duration. The spell ends on a target if it takes damage or someone within 5 feet of it takes an action to shake it out of the spell's effect.
 
 Creatures that don't sleep, such as elves, or that have Immunity to the Exhaustion condition automatically succeed on saves against this spell.
@@ -6031,7 +6031,7 @@ Source:	Player's Handbook 2024 p. 317</text>
     <range>150 feet</range>
     <components>V, S, M (a miniature umbrella)</components>
     <duration>Concentration, up to 1 minute</duration>
-    <classes>Druid [2024], Sorcerer [2024], Wizard [2024], Druid [2024] (Polar Land)</classes>
+    <classes>School: Conjuration, Druid [2024], Sorcerer [2024], Wizard [2024], Druid [2024] (Polar Land)</classes>
     <text>Until the spell ends, sleet falls in a 40-foot-tall, 20-foot-radius Cylinder centered on a point you choose within range. The area is Heavily Obscured, and exposed flames in the area are doused.
 
 Ground in the Cylinder is Difficult Terrain. When a creature enters the Cylinder for the first time on a turn or starts its turn there, it must succeed on a Dexterity saving throw or have the Prone condition and lose Concentration.
@@ -6046,7 +6046,7 @@ Source:	Player's Handbook 2024 p. 317</text>
     <range>120 feet</range>
     <components>V, S, M (a drop of molasses)</components>
     <duration>Concentration, up to 1 minute</duration>
-    <classes>Bard [2024], Sorcerer [2024], Wizard [2024]</classes>
+    <classes>School: Transmutation, Bard [2024], Sorcerer [2024], Wizard [2024]</classes>
     <text>You alter time around up to six creatures of your choice in a 40-foot Cube within range. Each target must succeed on a Wisdom saving throw or be affected by this spell for the duration.
 
 An affected target's Speed is halved, it takes a -2 penalty to AC and Dexterity saving throws, and it can't take Reactions. On its turns, it can take either an action or a Bonus Action, not both, and it can make only one attack if it takes the Attack action. If it casts a spell with a Somatic component, there is a 25 chance the spell fails as a result of the target making the spell's gestures too slowly.
@@ -6063,7 +6063,7 @@ Source:	Player's Handbook 2024 p. 318</text>
     <range>120 feet</range>
     <components>V, S</components>
     <duration>Instantaneous</duration>
-    <classes>Sorcerer [2024]</classes>
+    <classes>School: Evocation, Sorcerer [2024]</classes>
     <text>You cast sorcerous energy at one creature or object within range. Make a ranged attack roll against the target. On a hit, the target takes 1d8 damage of a type you choose: Acid, Cold, Fire, Lightning, Poison, Psychic, or Thunder.
 
 If you roll an 8 on a d8 for this spell, you can roll another d8, and add it to the damage. When you cast this spell, the maximum number of these d8s you can add to the spell's damage equals your spellcasting ability modifier.
@@ -6084,7 +6084,7 @@ Source:	Player's Handbook 2024 p. 318</text>
     <range>15 feet</range>
     <components>V, S</components>
     <duration>Instantaneous</duration>
-    <classes>Cleric [2024], Druid [2024]</classes>
+    <classes>School: Necromancy, Cleric [2024], Druid [2024]</classes>
     <text>Choose a creature within range that has 0 Hit Points and isn't dead. The creature becomes Stable.
 
 Cantrip Upgrade: The range doubles when you reach levels 5 (30 feet), 11 (60 feet), and 17 (120 feet).
@@ -6100,7 +6100,7 @@ Source:	Player's Handbook 2024 p. 318</text>
     <range>Self</range>
     <components>V, S</components>
     <duration>10 minute</duration>
-    <classes>Bard [2024], Druid [2024], Ranger [2024], Warlock [2024], Paladin [2024] (Ancient)</classes>
+    <classes>School: Divination, Bard [2024], Druid [2024], Ranger [2024], Warlock [2024], Paladin [2024] (Ancient)</classes>
     <text>For the duration, you can comprehend and verbally communicate with Beasts, and you can use any of the Influence action's skill options with them.
 
 Most Beasts have little to say about topics that don't pertain to survival or companionship, but at minimum, a Beast can give you information about nearby locations and monsters, including whatever it has perceived within the past day.
@@ -6115,7 +6115,7 @@ Source:	Player's Handbook 2024 p. 318</text>
     <range>10 feet</range>
     <components>V, S, M (burning incense)</components>
     <duration>10 minute</duration>
-    <classes>Bard [2024], Cleric [2024], Wizard [2024]</classes>
+    <classes>School: Necromancy, Bard [2024], Cleric [2024], Wizard [2024]</classes>
     <text>You grant the semblance of life to a corpse of your choice within range, allowing it to answer questions you pose. The corpse must have a mouth, and this spell fails if the deceased creature was Undead when it died. The spell also fails if the corpse was the target of this spell within the past 10 days.
 
 Until the spell ends, you can ask the corpse up to five questions. The corpse knows only what it knew in life, including the languages it knew. Answers are usually brief, cryptic, or repetitive, and the corpse is under no compulsion to offer a truthful answer if you are antagonistic toward it or it recognizes you as an enemy. This spell doesn't return the creature's soul to its body, only its animating spirit. Thus, the corpse can't learn new information, doesn't comprehend anything that has happened since it died, and can't speculate about future events.
@@ -6130,7 +6130,7 @@ Source:	Player's Handbook 2024 p. 318</text>
     <range>Self</range>
     <components>V, S</components>
     <duration>10 minute</duration>
-    <classes>Bard [2024], Druid [2024], Ranger [2024]</classes>
+    <classes>School: Transmutation, Bard [2024], Druid [2024], Ranger [2024]</classes>
     <text>You imbue plants in an immobile 30-foot Emanation with limited sentience and animation, giving them the ability to communicate with you and follow your simple commands. You can question plants about events in the spell's area within the past day, gaining information about creatures that have passed, weather, and other circumstances.
 
 You can also turn Difficult Terrain caused by plant growth (such as thickets and undergrowth) into ordinary terrain that lasts for the duration. Or you can turn ordinary terrain where plants are present into Difficult Terrain that lasts for the duration.
@@ -6149,7 +6149,7 @@ Source:	Player's Handbook 2024 p. 318</text>
     <range>Touch</range>
     <components>V, S, M (a drop of bitumen and a spider)</components>
     <duration>Concentration, up to 1 hour</duration>
-    <classes>Sorcerer [2024], Warlock [2024], Wizard [2024]</classes>
+    <classes>School: Transmutation, Sorcerer [2024], Warlock [2024], Wizard [2024]</classes>
     <text>Until the spell ends, one willing creature you touch gains the ability to move up, down, and across vertical surfaces and along ceilings, while leaving its hands free. The target also gains a Climb Speed equal to its Speed.
 
 Using a Higher-Level Spell Slot:
@@ -6165,7 +6165,7 @@ Source:	Player's Handbook 2024 p. 318</text>
     <range>150 feet</range>
     <components>V, S, M (seven thorns)</components>
     <duration>Concentration, up to 10 minute</duration>
-    <classes>Druid [2024], Ranger [2024]</classes>
+    <classes>School: Transmutation, Druid [2024], Ranger [2024]</classes>
     <text>The ground in a 20-foot-radius Sphere centered on a point within range sprouts hard spikes and thorns. The area becomes Difficult Terrain for the duration. When a creature moves into or within the area, it takes 2d4 Piercing damage for every 5 feet it travels.
 
 The transformation of the ground is camouflaged to look natural. Any creature that can't see the area when the spell is cast must take a Search action and succeed on a Wisdom (Perception or Survival) check against your spell save DC to recognize the terrain as hazardous before entering it.
@@ -6181,7 +6181,7 @@ Source:	Player's Handbook 2024 p. 318</text>
     <range>Self</range>
     <components>V, S, M (a prayer scroll)</components>
     <duration>Concentration, up to 10 minute</duration>
-    <classes>Cleric [2024], Cleric [2024] (War)</classes>
+    <classes>School: Conjuration, Cleric [2024], Cleric [2024] (War)</classes>
     <text>Protective spirits flit around you in a 15-foot Emanation for the duration. If you are good or neutral, their spectral form appears angelic or fey (your choice). If you are evil, they appear fiendish.
 
 When you cast this spell, you can designate creatures to be unaffected by it. Any other creature's Speed is halved in the Emanation, and whenever the Emanation enters a creature's space and whenever a creature enters the Emanation or ends its turn there, the creature must make a Wisdom saving throw. On a failed save, the creature takes 3d8 Radiant damage (if you are good or neutral) or 3d8 Necrotic damage (if you are evil). On a successful save, the creature takes half as much damage. A creature makes this save only once per turn.
@@ -6206,7 +6206,7 @@ Source:	Player's Handbook 2024 p. 319</text>
     <range>60 feet</range>
     <components>V, S</components>
     <duration>Concentration, up to 1 minute</duration>
-    <classes>Cleric [2024], Cleric [2024] (War)</classes>
+    <classes>School: Evocation, Cleric [2024], Cleric [2024] (War)</classes>
     <text>You create a floating, spectral force that resembles a weapon of your choice and lasts for the duration. The force appears within range in a space of your choice, and you can immediately make one melee spell attack against one creature within 5 feet of the force. On a hit, the target takes Force damage equal to 1d8 plus your spellcasting ability modifier.
 
 As a Bonus Action on your later turns, you can move the force up to 20 feet and repeat the attack against a creature within 5 feet of it.
@@ -6232,7 +6232,7 @@ Source:	Player's Handbook 2024 p. 319</text>
     <range>Self</range>
     <components>V</components>
     <duration>Instantaneous</duration>
-    <classes>Paladin [2024]</classes>
+    <classes>School: Enchantment, Paladin [2024]</classes>
     <text>The target takes an extra 4d6 Psychic damage from the attack, and the target must succeed on a Wisdom saving throw or have the Stunned condition until the end of your next turn.
 
 Using a Higher-Level Spell Slot:
@@ -6254,7 +6254,7 @@ Source:	Player's Handbook 2024 p. 320</text>
     <range>60 feet</range>
     <components>V, S</components>
     <duration>Instantaneous</duration>
-    <classes>Bard [2024], Druid [2024], Druid [2024] (Moon)</classes>
+    <classes>School: Evocation, Bard [2024], Druid [2024], Druid [2024] (Moon)</classes>
     <text>You launch a mote of light at one creature or object within range. Make a ranged spell attack against the target. On a hit, the target takes 1d8 Radiant damage, and until the end of your next turn, it emits Dim Light in a 10-foot radius and can't benefit from the Invisible condition.
 
 Cantrip Upgrade: The damage increases by 1d8 when you reach levels 5 (2d8), 11 (3d8), and 17 (4d8).
@@ -6273,7 +6273,7 @@ Source:	Player's Handbook 2024 p. 320</text>
     <range>30 feet</range>
     <components>S, M (a Melee weapon worth 1+ SP)</components>
     <duration>Instantaneous</duration>
-    <classes>Ranger [2024], Wizard [2024], Cleric [2024] (War)</classes>
+    <classes>School: Conjuration, Ranger [2024], Wizard [2024], Cleric [2024] (War)</classes>
     <text>You flourish the weapon used in the casting and then vanish to strike like the wind. Choose up to five creatures you can see within range. Make a melee spell attack against each target. On a hit, a target takes 6d10 Force damage.
 
 You then teleport to an unoccupied space you can see within 5 feet of one of the targets.
@@ -6289,7 +6289,7 @@ Source:	Player's Handbook 2024 p. 319</text>
     <range>90 feet</range>
     <components>V, S, M (a rotten egg)</components>
     <duration>Concentration, up to 1 minute</duration>
-    <classes>Bard [2024], Sorcerer [2024], Wizard [2024], Druid [2024] (Tropical Land), Warlock [2024] (Fiend)</classes>
+    <classes>School: Conjuration, Bard [2024], Sorcerer [2024], Wizard [2024], Druid [2024] (Tropical Land), Warlock [2024] (Fiend)</classes>
     <text>You create a 20-foot-radius Sphere of yellow, nauseating gas centered on a point within range. The cloud is Heavily Obscured. The cloud lingers in the air for the duration or until a strong wind (such as the one created by Gust of Wind) disperses it.
 
 Each creature that starts its turn in the Sphere must succeed on a Constitution saving throw or have the Poisoned condition until the end of the current turn. While Poisoned in this way, the creature can't take an action or a Bonus Action.
@@ -6304,7 +6304,7 @@ Source:	Player's Handbook 2024 p. 320</text>
     <range>Touch</range>
     <components>V, S, M (soft clay)</components>
     <duration>Instantaneous</duration>
-    <classes>Cleric [2024], Druid [2024], Wizard [2024]</classes>
+    <classes>School: Transmutation, Cleric [2024], Druid [2024], Wizard [2024]</classes>
     <text>You touch a stone object of Medium size or smaller or a section of stone no more than 5 feet in any dimension and form it into any shape you like. For example, you could shape a large rock into a weapon, statue, or coffer, or you could make a small passage through a wall that is 5 feet thick. You could also shape a stone door or its frame to seal the door shut. The object you create can have up to two hinges and a latch, but finer mechanical detail isn't possible.
 
 Source:	Player's Handbook 2024 p. 320</text>
@@ -6317,7 +6317,7 @@ Source:	Player's Handbook 2024 p. 320</text>
     <range>Touch</range>
     <components>V, S, M (diamond dust worth 100+ GP, which the spell consumes)</components>
     <duration>Concentration, up to 1 hour</duration>
-    <classes>Druid [2024], Ranger [2024], Sorcerer [2024], Wizard [2024], Paladin [2024] (Ancient)</classes>
+    <classes>School: Transmutation, Druid [2024], Ranger [2024], Sorcerer [2024], Wizard [2024], Paladin [2024] (Ancient)</classes>
     <text>Until the spell ends, one willing creature you touch has Resistance to Bludgeoning, Piercing, and Slashing damage.
 
 Source:	Player's Handbook 2024 p. 320</text>
@@ -6330,7 +6330,7 @@ Source:	Player's Handbook 2024 p. 320</text>
     <range>1 Miles</range>
     <components>V, S</components>
     <duration>Concentration, up to 1 minute</duration>
-    <classes>Druid [2024]</classes>
+    <classes>School: Conjuration, Druid [2024]</classes>
     <text>A churning storm cloud forms for the duration, centered on a point within range and spreading to a radius of 300 feet. Each creature under the cloud when it appears must succeed on a Constitution saving throw or take 2d6 Thunder damage and have the Deafened condition for the duration.
 
 At the start of each of your later turns, the storm produces different effects, as detailed below.
@@ -6357,7 +6357,7 @@ Source:	Player's Handbook 2024 p. 320</text>
     <range>30 feet</range>
     <components>V, M (a drop of honey)</components>
     <duration>Concentration, up to 8 hour</duration>
-    <classes>Bard [2024], Sorcerer [2024], Warlock [2024], Wizard [2024], Warlock [2024] (Fiend)</classes>
+    <classes>School: Enchantment, Bard [2024], Sorcerer [2024], Warlock [2024], Wizard [2024], Warlock [2024] (Fiend)</classes>
     <text>You suggest a course of activity—described in no more than 25 words—to one creature you can see within range that can hear and understand you. The suggestion must sound achievable and not involve anything that would obviously deal damage to the target or it allies. For example, you could say, "Fetch the key to the cult's treasure vault, and give the key to me." Or you could say, "Stop fighting, leave this library peacefully, and don't return."
 
 The target must succeed on a Wisdom saving throw or have the Charmed condition for the duration or until you or your allies deal damage to the target. The Charmed target pursues the suggestion to the best of its ability. The suggested activity can continue for the entire duration, but if the suggested activity can be completed in a shorter time, the spell ends for the target upon completing it.
@@ -6372,7 +6372,7 @@ Source:	Player's Handbook 2024 p. 320</text>
     <range>90 feet</range>
     <components>V, S, M (a pickled tentacle and an eyeball in a platinum-inlaid vial worth 400+ GP)</components>
     <duration>Concentration, up to 1 hour</duration>
-    <classes>Warlock [2024], Wizard [2024], Sorcerer [2024] (Aberrant), Warlock [2024] (Great Old One)</classes>
+    <classes>School: Conjuration, Warlock [2024], Wizard [2024], Sorcerer [2024] (Aberrant), Warlock [2024] (Great Old One)</classes>
     <text>You call forth an aberrant spirit. It manifests in an unoccupied space that you can see within range and uses the Aberrant Spirit stat block. When you cast the spell, choose Beholderkin, Mind Flayer, or Slaad. The creature resembles an Aberration of that kind, which determines certain details in its stat block. The creature disappears when it drops to 0 Hit Points or when the spell ends.
 
 The creature is an ally to you and your allies. In combat, it shares your Initiative count, but it takes its turn immediately after yours. It obeys your verbal commands (no action required by you). If you don't issue any, it takes the Dodge action and uses its movement to avoid danger.
@@ -6390,7 +6390,7 @@ Source:	Player's Handbook 2024 p. 322</text>
     <range>90 feet</range>
     <components>V, S, M (a feather, tuft of fur, and fish tail inside a gilded acorn worth 200+ GP)</components>
     <duration>Concentration, up to 1 hour</duration>
-    <classes>Druid [2024], Ranger [2024]</classes>
+    <classes>School: Conjuration, Druid [2024], Ranger [2024]</classes>
     <text>You call forth a bestial spirit. It manifests in an unoccupied space that you can see within range and uses the Bestial Spirit stat block. When you cast the spell, choose an environment: Air, Land, or Water. The creature resembles an animal of your choice that is native to the chosen environment, which determines certain details in its stat block. The creature disappears when it drops to 0 Hit Points or when the spell ends.
 
 The creature is an ally to you and your allies. In combat, the creature shares your Initiative count, but it takes its turn immediately after yours. It obeys your verbal commands (no action required by you). If you don't issue any, it takes the Dodge action and uses its movement to avoid danger.
@@ -6408,7 +6408,7 @@ Source:	Player's Handbook 2024 p. 322</text>
     <range>90 feet</range>
     <components>V, S, M (a reliquary worth 500+ GP)</components>
     <duration>Concentration, up to 1 hour</duration>
-    <classes>Cleric [2024], Paladin [2024], Warlock [2024] (Celestial)</classes>
+    <classes>School: Conjuration, Cleric [2024], Paladin [2024], Warlock [2024] (Celestial)</classes>
     <text>You call forth a Celestial spirit. It manifests in an angelic form in an unoccupied space that you can see within range and uses the Celestial Spirit stat block. When you cast the spell, choose Avenger or Defender. Your choice determines certain details in its stat block. The creature disappears when it drops to 0 Hit Points or when the spell ends.
 
 The creature is an ally to you and your allies. In combat, the creature shares your Initiative count, but it takes its turn immediately after yours. It obeys your verbal commands (no action required by you). If you don't issue any, it takes the Dodge action and uses its movement to avoid danger.
@@ -6426,7 +6426,7 @@ Source:	Player's Handbook 2024 p. 323</text>
     <range>90 feet</range>
     <components>V, S, M (a lockbox worth 400+ GP)</components>
     <duration>Concentration, up to 1 hour</duration>
-    <classes>Wizard [2024], Sorcerer [2024] (Clockwork)</classes>
+    <classes>School: Conjuration, Wizard [2024], Sorcerer [2024] (Clockwork)</classes>
     <text>You call forth the spirit of a Construct. It manifests in an unoccupied space that you can see within range and uses the Construct Spirit stat block. When you cast the spell, choose a material: Clay, Metal, or Stone. The creature resembles an animate statue (you determine the appearance) made of the chosen material, which determines certain details in its stat block. The creature disappears when it drops to 0 Hit Points or when the spell ends.
 
 The creature is an ally to you and your allies. In combat, the creature shares your Initiative count, but it takes its turn immediately after yours. It obeys your verbal commands (no action required by you). If you don't issue any, it takes the Dodge action and uses its movement to avoid danger.
@@ -6444,7 +6444,7 @@ Source:	Player's Handbook 2024 p. 324</text>
     <range>60 feet</range>
     <components>V, S, M (an object with the image of a dragon engraved on it worth 500+ GP)</components>
     <duration>Concentration, up to 1 hour</duration>
-    <classes>Wizard [2024], Sorcerer [2024] (Draconic)</classes>
+    <classes>School: Conjuration, Wizard [2024], Sorcerer [2024] (Draconic)</classes>
     <text>You call forth a Dragon spirit. It manifests in an unoccupied space that you can see within range and uses the Draconic Spirit stat block. The creature disappears when it drops to 0 Hit Points or when the spell ends.
 
 The creature is an ally to you and your allies. In combat, the creature shares your Initiative count, but it takes its turn immediately after yours. It obeys your verbal commands (no action required by you). If you don't issue any, it takes the Dodge action and uses its movement to avoid danger.
@@ -6462,7 +6462,7 @@ Source:	Player's Handbook 2024 p. 324</text>
     <range>90 feet</range>
     <components>V, S, M (air, a pebble, ash, and water inside a gold-inlaid vial worth 400+ GP)</components>
     <duration>Concentration, up to 1 hour</duration>
-    <classes>Druid [2024], Ranger [2024], Wizard [2024]</classes>
+    <classes>School: Conjuration, Druid [2024], Ranger [2024], Wizard [2024]</classes>
     <text>You call forth an Elemental spirit. It manifests in an unoccupied space that you can see within range and uses the Elemental Spirit stat block. When you cast the spell, choose an element: Air, Earth, Fire, or Water. The creature resembles a bipedal form wreathed in the chosen element, which determines certain details in its stat block. The creature disappears when it drops to 0 Hit Points or when the spell ends.
 
 The creature is an ally to you and your allies. In combat, the creature shares your Initiative count, but it takes its turn immediately after yours. It obeys your verbal commands (no action required by you). If you don't issue any, it takes the Dodge action and uses its movement to avoid danger.
@@ -6480,7 +6480,7 @@ Source:	Player's Handbook 2024 p. 325</text>
     <range>90 feet</range>
     <components>V, S, M (a gilded flower worth 300+ GP)</components>
     <duration>Concentration, up to 1 hour</duration>
-    <classes>Druid [2024], Ranger [2024], Warlock [2024], Wizard [2024], Ranger [2024] (Fey Wanderer)</classes>
+    <classes>School: Conjuration, Druid [2024], Ranger [2024], Warlock [2024], Wizard [2024], Ranger [2024] (Fey Wanderer)</classes>
     <text>You call forth a Fey spirit. It manifests in an unoccupied space that you can see within range and uses the Fey Spirit stat block. When you cast the spell, choose a mood: Fuming, Mirthful, or Tricksy. The creature resembles a Fey creature of your choice marked by the chosen mood, which determines certain details in its stat block. The creature disappears when it drops to 0 Hit Points or when the spell ends.
 
 The creature is an ally to you and your allies. In combat, the creature shares your Initiative count, but it takes its turn immediately after yours. It obeys your verbal commands (no action required by you). If you don't issue any, it takes the Dodge action and uses its movement to avoid danger.
@@ -6498,7 +6498,7 @@ Source:	Player's Handbook 2024 p. 326</text>
     <range>90 feet</range>
     <components>V, S, M (a bloody vial worth 600+ GP)</components>
     <duration>Concentration, up to 1 hour</duration>
-    <classes>Warlock [2024], Wizard [2024]</classes>
+    <classes>School: Conjuration, Warlock [2024], Wizard [2024]</classes>
     <text>You call forth a fiendish spirit. It manifests in an unoccupied space that you can see within range and uses the Fiendish Spirit stat block. When you cast the spell, choose Demon, Devil, or Yugoloth. The creature resembles a Fiend of the chosen type, which determines certain details in its stat block. The creature disappears when it drops to 0 Hit Points or when the spell ends.
 
 The creature is an ally to you and your allies. In combat, the creature shares your Initiative count, but it takes its turn immediately after yours. It obeys your verbal commands (no action required by you). If you don't issue any, it takes the Dodge action and uses its movement to avoid danger.
@@ -6516,7 +6516,7 @@ Source:	Player's Handbook 2024 p. 326</text>
     <range>90 feet</range>
     <components>V, S, M (a gilded skull worth 300+ GP)</components>
     <duration>Concentration, up to 1 hour</duration>
-    <classes>Warlock [2024], Wizard [2024]</classes>
+    <classes>School: Necromancy, Warlock [2024], Wizard [2024]</classes>
     <text>You call forth an Undead spirit. It manifests in an unoccupied space that you can see within range and uses the Undead Spirit stat block. When you cast the spell, choose the creature's form: Ghostly, Putrid, or Skeletal. The spirit resembles an Undead creature with the chosen form, which determines certain details in its stat block. The creature disappears when it drops to 0 Hit Points or when the spell ends.
 
 The creature is an ally to you and your allies. In combat, the creature shares your Initiative count, but it takes its turn immediately after yours. It obeys your verbal commands (no action required by you). If you don't issue any, it takes the Dodge action and uses its movement to avoid danger.
@@ -6534,7 +6534,7 @@ Source:	Player's Handbook 2024 p. 328</text>
     <range>60 feet</range>
     <components>V, S, M (a magnifying glass)</components>
     <duration>Concentration, up to 1 minute</duration>
-    <classes>Cleric [2024], Druid [2024], Sorcerer [2024], Wizard [2024]</classes>
+    <classes>School: Evocation, Cleric [2024], Druid [2024], Sorcerer [2024], Wizard [2024]</classes>
     <text>You launch a sunbeam in a 5-foot-wide, 60-foot-long Line. Each creature in the Line makes a Constitution saving throw. On a failed save, a creature takes 6d8 Radiant damage and has the Blinded condition until the start of your next turn. On a successful save, it takes half as much damage only.
 
 Until the spell ends, you can take a Magic action to create a new Line of radiance.
@@ -6552,7 +6552,7 @@ Source:	Player's Handbook 2024 p. 329</text>
     <range>150 feet</range>
     <components>V, S, M (a piece of sunstone)</components>
     <duration>Instantaneous</duration>
-    <classes>Cleric [2024], Druid [2024], Sorcerer [2024], Wizard [2024]</classes>
+    <classes>School: Evocation, Cleric [2024], Druid [2024], Sorcerer [2024], Wizard [2024]</classes>
     <text>Brilliant sunlight flashes in a 60-foot-radius Sphere centered on a point you choose within range. Each creature in the Sphere makes a Constitution saving throw. On a failed save, a creature takes 12d6 Radiant damage and has the Blinded condition for 1 minute. On a successful save, it takes half as much damage only.
 
 A creature Blinded by this spell makes another Constitution saving throw at the end of each of its turns, ending the effect on itself on a success.
@@ -6570,7 +6570,7 @@ Source:	Player's Handbook 2024 p. 329</text>
     <range>Self</range>
     <components>V, S, M (a Quiver worth 1+ GP)</components>
     <duration>Concentration, up to 1 minute</duration>
-    <classes>Ranger [2024]</classes>
+    <classes>School: Transmutation, Ranger [2024]</classes>
     <text>When you cast the spell and as a Bonus Action until it ends, you can make two attacks with a weapon that fires Arrows or Bolts, such as a Longbow or a Light Crossbow. The spell magically creates the ammunition needed for each attack. Each Arrow or Bolt created by the spell deals damage like a nonmagical piece of ammunition of its kind and disintegrates immediately after it hits or misses.
 
 Source:	Player's Handbook 2024 p. 329</text>
@@ -6583,7 +6583,7 @@ Source:	Player's Handbook 2024 p. 329</text>
     <range>Touch</range>
     <components>V, S, M (powdered diamond worth 1,000+ GP, which the spell consumes)</components>
     <duration/>
-    <classes>Bard [2024], Cleric [2024], Druid [2024], Wizard [2024]</classes>
+    <classes>School: Abjuration, Bard [2024], Cleric [2024], Druid [2024], Wizard [2024]</classes>
     <text>You inscribe a harmful glyph either on a surface (such as a section of floor or wall) or within an object that can be closed (such as a book or chest). The glyph can cover an area no larger than 10 feet in diameter. If you choose an object, it must remain in place; if it is moved more than 10 feet from where you cast this spell, the glyph is broken, and the spell ends without being triggered.
 
 The glyph is nearly imperceptible and requires a successful Wisdom (Perception) check against your spell save DC to notice.
@@ -6626,7 +6626,7 @@ Source:	Player's Handbook 2024 p. 329</text>
     <range>120 feet</range>
     <components>V, S</components>
     <duration>Instantaneous</duration>
-    <classes>Bard [2024], Sorcerer [2024], Warlock [2024], Wizard [2024]</classes>
+    <classes>School: Enchantment, Bard [2024], Sorcerer [2024], Warlock [2024], Wizard [2024]</classes>
     <text>You cause psychic energy to erupt at a point within range. Each creature in a 20-foot-radius Sphere centered on that point makes an Intelligence saving throw, taking 8d6 Psychic damage on a failed save or half as much damage on a successful one.
 
 On a failed save, a target also has muddled thoughts for 1 minute. During that time, it subtracts 1d6 from all its attack rolls and ability checks, as well as any Constitution saving throws to maintain Concentration. The target makes an Intelligence saving throw at the end of each of its turns, ending the effect on itself on a success.
@@ -6643,7 +6643,7 @@ Source:	Player's Handbook 2024 p. 330</text>
     <range>5 feet</range>
     <components>V, S, M (a gilded ladle worth 500 + GP)</components>
     <duration>10 minute</duration>
-    <classes>Warlock [2024], Wizard [2024]</classes>
+    <classes>School: Conjuration, Warlock [2024], Wizard [2024]</classes>
     <text>You conjure a claw-footed cauldron filled with bubbling liquid. The cauldron appears in an unoccupied space on the ground within 5 feet of you and lasts for the duration. The cauldron can't be moved and disappears when the spell ends, along with the bubbling liquid inside it.
 
 The liquid in the cauldron duplicates the properties of a Common or an Uncommon potion of your choice (such as a Potion of Healing). As a Bonus Action, you or an ally can reach into the cauldron and withdraw one potion of that kind. The potion is contained in a vial that disappears when the potion is consumed. The cauldron can produce a number of these potions equal to your spellcasting ability modifier (minimum 1). When the last of these potions is withdrawn from the cauldron, the cauldron disappears, and the spell ends.
@@ -6660,7 +6660,7 @@ Source:	Player's Handbook 2024 p. 330</text>
     <range>30 feet</range>
     <components>V, S, M (a tart and a feather)</components>
     <duration>Concentration, up to 1 minute</duration>
-    <classes>Bard [2024], Warlock [2024], Wizard [2024], Warlock [2024] (Great Old One)</classes>
+    <classes>School: Enchantment, Bard [2024], Warlock [2024], Wizard [2024], Warlock [2024] (Great Old One)</classes>
     <text>One creature of your choice that you can see within range makes a Wisdom saving throw. On a failed save, it has the Prone and Incapacitated conditions for the duration. During that time, it laughs uncontrollably if it's capable of laughter, and it can't end the Prone condition on itself.
 
 At the end of each of its turns and each time it takes damage, it makes another Wisdom saving throw. The target has Advantage on the save if the save is triggered by damage. On a successful save, the spell ends.
@@ -6678,7 +6678,7 @@ Source:	Player's Handbook 2024 p. 331</text>
     <range>60 feet</range>
     <components>V, S</components>
     <duration>Concentration, up to 10 minute</duration>
-    <classes>Sorcerer [2024], Wizard [2024], Sorcerer [2024] (Aberrant), Warlock [2024] (Great Old One)</classes>
+    <classes>School: Transmutation, Sorcerer [2024], Wizard [2024], Sorcerer [2024] (Aberrant), Warlock [2024] (Great Old One)</classes>
     <text>You gain the ability to move or manipulate creatures or objects by thought. When you cast the spell and as a Magic action on your later turns before the spell ends, you can exert your will on one creature or object that you can see within range, causing the appropriate effect below. You can affect the same target round after round or choose a new one at any time. If you switch targets, the prior target is no longer affected by the spell.
 
 Creature:
@@ -6701,7 +6701,7 @@ Source:	Player's Handbook 2024 p. 331</text>
     <range>Unlimited</range>
     <components>V, S, M (a pair of linked silver rings)</components>
     <duration>24 hour</duration>
-    <classes>Wizard [2024]</classes>
+    <classes>School: Divination, Wizard [2024]</classes>
     <text>You create a telepathic link between yourself and a willing creature with which you are familiar. The creature can be anywhere on the same plane of existence as you. The spell ends if you or the target are no longer on the same plane.
 
 Until the spell ends, you and the target can instantly share words, images, sounds, and other sensory messages with each other through the link, and the target recognizes you as the creature it is communicating with. The spell enables a creature to understand the meaning of your words and any sensory messages you send to it.
@@ -6716,7 +6716,7 @@ Source:	Player's Handbook 2024 p. 331</text>
     <range>10 feet</range>
     <components>V</components>
     <duration>Instantaneous</duration>
-    <classes>Bard [2024], Sorcerer [2024], Wizard [2024]</classes>
+    <classes>School: Conjuration, Bard [2024], Sorcerer [2024], Wizard [2024]</classes>
     <text>This spell instantly transports you and up to eight willing creatures that you can see within range, or a single object that you can see within range, to a destination you select. If you target an object, it must be Large or smaller, and it can't be held or carried by an unwilling creature.
 
 The destination you choose must be known to you, and it must be on the same plane of existence as you. Your familiarity with the destination determines whether you arrive there successfully. The DM rolls 1d100 and consults the Teleportation Outcome table and the explanations after it.
@@ -6770,7 +6770,7 @@ Source:	Player's Handbook 2024 p. 331</text>
     <range>10 feet</range>
     <components>V, M (rare inks worth 50+ GP, which the spell consumes)</components>
     <duration>1 round</duration>
-    <classes>Bard [2024], Sorcerer [2024], Warlock [2024], Wizard [2024]</classes>
+    <classes>School: Conjuration, Bard [2024], Sorcerer [2024], Warlock [2024], Wizard [2024]</classes>
     <text>As you cast the spell, you draw a 5-foot-radius circle on the ground inscribed with sigils that link your location to a permanent teleportation circle of your choice whose sigil sequence you know and that is on the same plane of existence as you. A shimmering portal opens within the circle you drew and remains open until the end of your next turn. Any creature that enters the portal instantly appears within 5 feet of the destination circle or in the nearest unoccupied space if that space is occupied.
 
 Many major temples, guildhalls, and other important places have permanent teleportation circles. Each circle includes a unique sigil sequence—a string of runes arranged in a particular pattern.
@@ -6790,7 +6790,7 @@ Source:	Player's Handbook 2024 p. 332</text>
     <range>30 feet</range>
     <components>V, S, M (a drop of mercury)</components>
     <duration>1 hour</duration>
-    <classes>Wizard [2024]</classes>
+    <classes>School: Conjuration, Wizard [2024]</classes>
     <text>This spell creates a circular, horizontal plane of force, 3 feet in diameter and 1 inch thick, that floats 3 feet above the ground in an unoccupied space of your choice that you can see within range. The disk remains for the duration and can hold up to 500 pounds. If more weight is placed on it, the spell ends, and everything on the disk falls to the ground.
 
 The disk is immobile while you are within 20 feet of it. If you move more than 20 feet away from it, the disk follows you so that it remains within 20 feet of you. It can move across uneven terrain, up or down stairs, slopes and the like, but it can't cross an elevation change of 10 feet or more. For example, the disk can't move across a 10-foot-deep pit, nor could it leave such a pit if it was created at the bottom.
@@ -6807,7 +6807,7 @@ Source:	Player's Handbook 2024 p. 332</text>
     <range>30 feet</range>
     <components>V</components>
     <duration>1 minute</duration>
-    <classes>Cleric [2024]</classes>
+    <classes>School: Transmutation, Cleric [2024]</classes>
     <text>You manifest a minor wonder within range. You create one of the effects below within range. If you cast this spell multiple times, you can have up to three of its 1-minute effects active at a time.
 
 Altered Eyes:
@@ -6838,7 +6838,7 @@ Source:	Player's Handbook 2024 p. 333</text>
     <range>30 feet</range>
     <components>V, S, M (the stem of a plant with thorns)</components>
     <duration>Instantaneous</duration>
-    <classes>Druid [2024]</classes>
+    <classes>School: Transmutation, Druid [2024]</classes>
     <text>You create a vine-like whip covered in thorns that lashes out at your command toward a creature in range. Make a melee spell attack against the target. On a hit, the target takes 1d6 Piercing damage, and if it is Large or smaller, you can pull it up to 10 feet closer to you.
 
 Cantrip Upgrade: The damage increases by 1d6 when you reach levels 5 (2d6), 11 (3d6), and 17 (4d6).
@@ -6857,7 +6857,7 @@ Source:	Player's Handbook 2024 p. 333</text>
     <range>Self</range>
     <components>S</components>
     <duration>Instantaneous</duration>
-    <classes>Bard [2024], Druid [2024], Sorcerer [2024], Warlock [2024], Wizard [2024]</classes>
+    <classes>School: Evocation, Bard [2024], Druid [2024], Sorcerer [2024], Warlock [2024], Wizard [2024]</classes>
     <text>Each creature in a 5-foot Emanation originating from you must succeed on a Constitution saving throw or take 1d6 Thunder damage. The spell's thunderous sound can be heard up to 100 feet away.
 
 Cantrip Upgrade: The damage increases by 1d6 when you reach levels 5 (2d6), 11 (3d6), and 17 (4d6).
@@ -6876,7 +6876,7 @@ Source:	Player's Handbook 2024 p. 333</text>
     <range>Self</range>
     <components>V</components>
     <duration>Instantaneous</duration>
-    <classes>Paladin [2024]</classes>
+    <classes>School: Evocation, Paladin [2024]</classes>
     <text>Your strike rings with thunder that is audible within 300 feet of you, and the target takes an extra 2d6 Thunder damage from the attack. Additionally, if the target is a creature, it must succeed on a Strength saving throw or be pushed 10 feet away from you and have the Prone condition.
 
 Using a Higher-Level Spell Slot:
@@ -6901,7 +6901,7 @@ Source:	Player's Handbook 2024 p. 334</text>
     <range>15 feet</range>
     <components>V, S</components>
     <duration>Instantaneous</duration>
-    <classes>Bard [2024], Druid [2024], Sorcerer [2024], Wizard [2024], Druid [2024] (Sea)</classes>
+    <classes>School: Evocation, Bard [2024], Druid [2024], Sorcerer [2024], Wizard [2024], Druid [2024] (Sea)</classes>
     <text>You unleash a wave of thunderous energy. Each creature in a 15-foot Cube originating from you makes a Constitution saving throw. On a failed save, a creature takes 2d8 Thunder damage and is pushed 10 feet away from you. On a successful save, a creature takes half as much damage only.
 
 In addition, unsecured objects that are entirely within the Cube are pushed 10 feet away from you, and a thunderous boom is audible within 300 feet.
@@ -6928,7 +6928,7 @@ Source:	Player's Handbook 2024 p. 334</text>
     <range>Self</range>
     <components>V</components>
     <duration>Instantaneous</duration>
-    <classes>Sorcerer [2024], Wizard [2024]</classes>
+    <classes>School: Transmutation, Sorcerer [2024], Wizard [2024]</classes>
     <text>You briefly stop the flow of time for everyone but yourself. No time passes for other creatures, while you take 1d4 + 1 turns in a row, during which you can use actions and move as normal.
 
 This spell ends if one of the actions you use during this period, or any effects that you create during it, affects a creature other than you or an object being worn or carried by someone other than you. In addition, the spell ends if you move to a place more than 1,000 feet from the location where you cast it.
@@ -6944,7 +6944,7 @@ Source:	Player's Handbook 2024 p. 334</text>
     <range>60 feet</range>
     <components>V, S</components>
     <duration>Instantaneous</duration>
-    <classes>Cleric [2024], Warlock [2024], Wizard [2024]</classes>
+    <classes>School: Necromancy, Cleric [2024], Warlock [2024], Wizard [2024]</classes>
     <text>You point at one creature you can see within range, and the single chime of a dolorous bell is audible within 10 feet of the target. The target must succeed on a Wisdom saving throw or take 1d8 Necrotic damage. If the target is missing any of its Hit Points, it instead takes 1d12 Necrotic damage.
 
 Cantrip Upgrade: The damage increases by one die when you reach levels 5 (2d8 or 2d12), 11 (3d8 or 3d12), and 17 (4d8 or 4d12).
@@ -6964,7 +6964,7 @@ Source:	Player's Handbook 2024 p. 334</text>
     <range>Touch</range>
     <components>V, M (a miniature ziggurat)</components>
     <duration>1 hour</duration>
-    <classes>Bard [2024], Cleric [2024], Sorcerer [2024], Warlock [2024], Wizard [2024]</classes>
+    <classes>School: Divination, Bard [2024], Cleric [2024], Sorcerer [2024], Warlock [2024], Wizard [2024]</classes>
     <text>This spell grants the creature you touch the ability to understand any spoken or signed language that it hears or sees. Moreover, when the target communicates by speaking or signing, any creature that knows at least one language can understand it if that creature can hear the speech or see the signing.
 
 Source:	Player's Handbook 2024 p. 334</text>
@@ -6977,7 +6977,7 @@ Source:	Player's Handbook 2024 p. 334</text>
     <range>10 feet</range>
     <components>V, S</components>
     <duration>1 round</duration>
-    <classes>Druid [2024]</classes>
+    <classes>School: Conjuration, Druid [2024]</classes>
     <text>This spell creates a magical link between a Large or larger inanimate plant within range and another plant, at any distance, on the same plane of existence. You must have seen or touched the destination plant at least once before. For the duration, any creature can step into the target plant and exit from the destination plant by using 5 feet of movement.
 
 Source:	Player's Handbook 2024 p. 334</text>
@@ -6990,7 +6990,7 @@ Source:	Player's Handbook 2024 p. 334</text>
     <range>Self</range>
     <components>V, S</components>
     <duration>Concentration, up to 1 minute</duration>
-    <classes>Druid [2024], Ranger [2024], Druid [2024] (Temperate Land), Paladin [2024] (Ancient)</classes>
+    <classes>School: Conjuration, Druid [2024], Ranger [2024], Druid [2024] (Temperate Land), Paladin [2024] (Ancient)</classes>
     <text>You gain the ability to enter a tree and move from inside it to inside another tree of the same kind within 500 feet. Both trees must be living and at least the same size as you. You must use 5 feet of movement to enter a tree. You instantly know the location of all other trees of the same kind within 500 feet and, as part of the move used to enter the tree, can either pass into one of those trees or step out of the tree you're in. You appear in a spot of your choice within 5 feet of the destination tree, using another 5 feet of movement. If you have no movement left, you appear within 5 feet of the tree you entered.
 
 You can use this transportation ability only once on each of your turns. You must end each turn outside a tree.
@@ -7005,7 +7005,7 @@ Source:	Player's Handbook 2024 p. 335</text>
     <range>30 feet</range>
     <components>V, S, M (a drop of mercury, a dollop of gum arabic, and a wisp of smoke)</components>
     <duration>Concentration, up to 1 hour</duration>
-    <classes>Bard [2024], Warlock [2024], Wizard [2024]</classes>
+    <classes>School: Transmutation, Bard [2024], Warlock [2024], Wizard [2024]</classes>
     <text>Choose one creature or nonmagical object that you can see within range. The creature shape-shifts into a different creature or a nonmagical object, or the object shape-shifts into a creature (the object must be neither worn nor carried). The transformation lasts for the duration or until the target dies or is destroyed, but if you maintain Concentration on this spell for the full duration, the spell lasts until dispelled.
 
 An unwilling creature can make a Wisdom saving throw, and if it succeeds, it isn't affected by this spell.
@@ -7037,7 +7037,7 @@ Source:	Player's Handbook 2024 p. 335</text>
     <range>Touch</range>
     <components>V, S, M (diamonds worth 25,000+ GP, which the spell consumes)</components>
     <duration>Instantaneous</duration>
-    <classes>Cleric [2024], Druid [2024]</classes>
+    <classes>School: Necromancy, Cleric [2024], Druid [2024]</classes>
     <text>You touch a creature that has been dead for no longer than 200 years and that died for any reason except old age. The creature is revived with all its Hit Points.
 
 This spell closes all wounds, neutralizes any poison, cures all magical contagions, and lifts any curses affecting the creature when it died. The spell replaces damaged or missing organs and limbs. If the creature was Undead, it is restored to its non-Undead form.
@@ -7054,7 +7054,7 @@ Source:	Player's Handbook 2024 p. 336</text>
     <range>Touch</range>
     <components>V, S, M (mushroom powder worth 25+ GP, which the spell consumes)</components>
     <duration>1 hour</duration>
-    <classes>Bard [2024], Cleric [2024], Sorcerer [2024], Warlock [2024], Wizard [2024]</classes>
+    <classes>School: Divination, Bard [2024], Cleric [2024], Sorcerer [2024], Warlock [2024], Wizard [2024]</classes>
     <text>For the duration, the willing creature you touch has Truesight with a range of 120 feet.
 
 Source:	Player's Handbook 2024 p. 336</text>
@@ -7067,7 +7067,7 @@ Source:	Player's Handbook 2024 p. 336</text>
     <range>Self</range>
     <components>S, M (a weapon with which you have proficiency and that is worth 1+ CP)</components>
     <duration>Instantaneous</duration>
-    <classes>Bard [2024], Sorcerer [2024], Warlock [2024], Wizard [2024]</classes>
+    <classes>School: Divination, Bard [2024], Sorcerer [2024], Warlock [2024], Wizard [2024]</classes>
     <text>Guided by a flash of magical insight, you make one attack with the weapon used in the spell's casting. The attack uses your spellcasting ability for the attack and damage rolls instead of using Strength or Dexterity. If the attack deals damage, it can be Radiant damage or the weapon's normal damage type (your choice).
 
 Cantrip Upgrade: Whether you deal Radiant damage or the weapon's normal damage type, the attack deals extra Radiant damage when you reach levels 5 (1d6), 11 (2d6), and 17 (3d6).
@@ -7082,7 +7082,7 @@ Source:	Player's Handbook 2024 p. 336</text>
     <range>1 Miles</range>
     <components>V, S</components>
     <duration>Concentration, up to 6 round</duration>
-    <classes>Druid [2024]</classes>
+    <classes>School: Conjuration, Druid [2024]</classes>
     <text>A wall of water springs into existence at a point you choose within range. You can make the wall up to 300 feet long, 300 feet high, and 50 feet thick. The wall lasts for the duration.
 
 When the wall appears, each creature in its area makes a Strength saving throw, taking 6d10 Bludgeoning damage on a failed save or half as much damage on a successful one.
@@ -7105,7 +7105,7 @@ Source:	Player's Handbook 2024 p. 336</text>
     <range>60 feet</range>
     <components>V, S, M (a bit of string and of wood)</components>
     <duration>1 hour</duration>
-    <classes>Bard [2024], Warlock [2024], Wizard [2024]</classes>
+    <classes>School: Conjuration, Bard [2024], Warlock [2024], Wizard [2024]</classes>
     <text>This spell creates an Invisible, mindless, shapeless, Medium force that performs simple tasks at your command until the spell ends. The servant springs into existence in an unoccupied space on the ground within range. It has AC 10, 1 Hit Point, and a Strength of 2, and it can't attack. If it drops to 0 Hit Points, the spell ends.
 
 Once on each of your turns as a Bonus Action, you can mentally command the servant to move up to 15 feet and interact with an object. The servant can perform simple tasks that a human could do, such as fetching things, cleaning, mending, folding clothes, lighting fires, serving food, and pouring drinks. Once you give the command, the servant performs the task to the best of its ability until it completes the task, then waits for your next command.
@@ -7122,7 +7122,7 @@ Source:	Player's Handbook 2024 p. 336</text>
     <range>Self</range>
     <components>V, S</components>
     <duration>Concentration, up to 1 minute</duration>
-    <classes>Sorcerer [2024], Warlock [2024], Wizard [2024]</classes>
+    <classes>School: Necromancy, Sorcerer [2024], Warlock [2024], Wizard [2024]</classes>
     <text>The touch of your shadow-wreathed hand can siphon life force from others to heal your wounds. Make a melee spell attack against one creature within reach. On a hit, the target takes 3d6 Necrotic damage, and you regain Hit Points equal to half the amount of Necrotic damage dealt.
 
 Until the spell ends, you can make the attack again on each of your turns as a Magic action, targeting the same creature or a different one.
@@ -7147,7 +7147,7 @@ Source:	Player's Handbook 2024 p. 337</text>
     <range>60 feet</range>
     <components>V</components>
     <duration>Instantaneous</duration>
-    <classes>Bard [2024]</classes>
+    <classes>School: Enchantment, Bard [2024]</classes>
     <text>You unleash a string of insults laced with subtle enchantments at one creature you can see or hear within range. The target must succeed on a Wisdom saving throw or take 1d6 Psychic damage and have Disadvantage on the next attack roll it makes before the end of its next turn.
 
 Cantrip Upgrade: The damage increases by 1d6 when you reach levels 5 (2d6), 11 (3d6), and 17 (4d6).
@@ -7166,7 +7166,7 @@ Source:	Player's Handbook 2024 p. 337</text>
     <range>150 feet</range>
     <components>V, S, M (a drop bile)</components>
     <duration>Instantaneous</duration>
-    <classes>Sorcerer [2024], Wizard [2024]</classes>
+    <classes>School: Evocation, Sorcerer [2024], Wizard [2024]</classes>
     <text>You point at a location within range, and a glowing, 1-foot-diameter ball of acid streaks there and explodes in a 20-foot-radius Sphere. Each creature in that area makes a Dexterity saving throw. On a failed save, a creature takes 10d4 Acid damage and another 5d4 Acid damage at the end of its next turn. On a successful save, a creature takes half the initial damage only.
 
 Using a Higher-Level Spell Slot:
@@ -7189,7 +7189,7 @@ Source:	Player's Handbook 2024 p. 337</text>
     <range>120 feet</range>
     <components>V, S, M (a piece of charcoal)</components>
     <duration>Concentration, up to 1 minute</duration>
-    <classes>Druid [2024], Sorcerer [2024], Wizard [2024], Cleric [2024] (Light), Warlock [2024] (Celestial), Warlock [2024] (Fiend)</classes>
+    <classes>School: Evocation, Druid [2024], Sorcerer [2024], Wizard [2024], Cleric [2024] (Light), Warlock [2024] (Celestial), Warlock [2024] (Fiend)</classes>
     <text>You create a wall of fire on a solid surface within range. You can make the wall up to 60 feet long, 20 feet high, and 1 foot thick, or a ringed wall up to 20 feet in diameter, 20 feet high, and 1 foot thick. The wall is opaque and lasts for the duration.
 
 When the wall appears, each creature in its area makes a Dexterity saving throw, taking 5d8 Fire damage on a failed save or half as much damage on a successful one.
@@ -7215,7 +7215,7 @@ Source:	Player's Handbook 2024 p. 338</text>
     <range>120 feet</range>
     <components>V, S, M (a shard of glass)</components>
     <duration>Concentration, up to 10 minute</duration>
-    <classes>Wizard [2024], Sorcerer [2024] (Clockwork)</classes>
+    <classes>School: Evocation, Wizard [2024], Sorcerer [2024] (Clockwork)</classes>
     <text>An Invisible wall of force springs into existence at a point you choose within range. The wall appears in any orientation you choose, as a horizontal or vertical barrier or at an angle. It can be free floating or resting on a solid surface. You can form it into a hemispherical dome or a globe with a radius of up to 10 feet, or you can shape a flat surface made up of ten 10-foot-by-10-foot panels. Each panel must be contiguous with another panel. In any form, the wall is 1/4 inch thick and lasts for the duration. If the wall cuts through a creature's space when it appears, the creature is pushed to one side of the wall (you choose which side).
 
 Nothing can physically pass through the wall. It is immune to all damage and can't be dispelled by Dispel Magic. A Disintegrate spell destroys the wall instantly, however. The wall also extends into the Ethereal Plane and blocks ethereal travel through the wall.
@@ -7230,7 +7230,7 @@ Source:	Player's Handbook 2024 p. 338</text>
     <range>120 feet</range>
     <components>V, S, M (a piece of quartz)</components>
     <duration>Concentration, up to 10 minute</duration>
-    <classes>Wizard [2024]</classes>
+    <classes>School: Evocation, Wizard [2024]</classes>
     <text>You create a wall of ice on a solid surface within range. You can form it into a hemispherical dome or a globe with a radius of up to 10 feet, or you can shape a flat surface made up of ten 10-foot-square panels. Each panel must be contiguous with another panel. In any form, the wall is 1 foot thick and lasts for the duration.
 
 If the wall cuts through a creature's space when it appears, the creature is pushed to one side of the wall (you choose which side) and makes a Dexterity saving throw, taking 10d6 Cold damage on a failed save or half as much damage on a successful one.
@@ -7260,7 +7260,7 @@ Source:	Player's Handbook 2024 p. 339</text>
     <range>120 feet</range>
     <components>V, S, M (a cube of granite)</components>
     <duration>Concentration, up to 10 minute</duration>
-    <classes>Druid [2024], Sorcerer [2024], Wizard [2024], Druid [2024] (Arid Land)</classes>
+    <classes>School: Evocation, Druid [2024], Sorcerer [2024], Wizard [2024], Druid [2024] (Arid Land)</classes>
     <text>A nonmagical wall of solid stone springs into existence at a point you choose within range. The wall is 6 inches thick and is composed of ten 10-foot-by-10-foot panels. Each panel must be contiguous with another panel. Alternatively, you can create 10-foot-by-20-foot panels that are only 3 inches thick.
 
 If the wall cuts through a creature's space when it appears, the creature is pushed to one side of the wall (you choose which side). If a creature would be surrounded on all sides by the wall (or the wall and another solid surface), that creature can make a Dexterity saving throw. On a success, it can use its Reaction to move up to its Speed so that it is no longer enclosed by the wall.
@@ -7283,7 +7283,7 @@ Source:	Player's Handbook 2024 p. 339</text>
     <range>120 feet</range>
     <components>V, S, M (a handful of thorns)</components>
     <duration>Concentration, up to 10 minute</duration>
-    <classes>Druid [2024]</classes>
+    <classes>School: Conjuration, Druid [2024]</classes>
     <text>You create a wall of tangled brush bristling with needle-sharp thorns. The wall appears within range on a solid surface and lasts for the duration. You choose to make the wall up to 60 feet long, 10 feet high, and 5 feet thick or a circle that has a 20-foot diameter and is up to 20 feet high and 5 feet thick. The wall blocks line of sight.
 
 When the wall appears, each creature in its area makes a Dexterity saving throw, taking 7d8 Piercing damage on a failed save or half as much damage on a successful one.
@@ -7307,7 +7307,7 @@ Source:	Player's Handbook 2024 p. 339</text>
     <range>Touch</range>
     <components>V, S, M (a pair of platinum rings worth 50+ GP each, which you and the target must wear for the duration)</components>
     <duration>1 hour</duration>
-    <classes>Cleric [2024], Paladin [2024]</classes>
+    <classes>School: Abjuration, Cleric [2024], Paladin [2024]</classes>
     <text>You touch another creature that is willing and create a mystic connection between you and the target until the spell ends. While the target is within 60 feet of you, it gains a +1 bonus to AC and saving throws, and it has Resistance to all damage. Also, each time it takes damage, you take the same amount of damage.
 
 The spell ends if you drop to 0 Hit Points or if you and the target become separated by more than 60 feet. It also ends if the spell is cast again on either of the connected creatures.
@@ -7323,7 +7323,7 @@ Source:	Player's Handbook 2024 p. 340</text>
     <range>30 feet</range>
     <components>V, S, M (a short reed)</components>
     <duration>24 hour</duration>
-    <classes>Druid [2024], Ranger [2024], Sorcerer [2024], Wizard [2024], Druid [2024] (Sea)</classes>
+    <classes>School: Transmutation, Druid [2024], Ranger [2024], Sorcerer [2024], Wizard [2024], Druid [2024] (Sea)</classes>
     <text>This spell grants up to ten willing creatures of your choice within range the ability to breathe underwater until the spell ends. Affected creatures also retain their normal mode of respiration.
 
 Source:	Player's Handbook 2024 p. 340</text>
@@ -7337,7 +7337,7 @@ Source:	Player's Handbook 2024 p. 340</text>
     <range>30 feet</range>
     <components>V, S, M (a piece of cork)</components>
     <duration>1 hour</duration>
-    <classes>Cleric [2024], Druid [2024], Ranger [2024], Sorcerer [2024]</classes>
+    <classes>School: Transmutation, Cleric [2024], Druid [2024], Ranger [2024], Sorcerer [2024]</classes>
     <text>This spell grants the ability to move across any liquid surface—such as water, acid, mud, snow, quicksand, or lava—as if it were harmless solid ground (creatures crossing molten lava can still take damage from the heat). Up to ten willing creatures of your choice within range gain this ability for the duration.
 
 An affected target must take a Bonus Action to pass from the liquid's surface into the liquid itself and vice versa, but if the target falls into the liquid, the target passes through the surface into the liquid below.
@@ -7352,7 +7352,7 @@ Source:	Player's Handbook 2024 p. 340</text>
     <range>60 feet</range>
     <components>V, S, M (a bit of spiderweb)</components>
     <duration>Concentration, up to 1 hour</duration>
-    <classes>Sorcerer [2024], Wizard [2024], Druid [2024] (Tropical Land)</classes>
+    <classes>School: Conjuration, Sorcerer [2024], Wizard [2024], Druid [2024] (Tropical Land)</classes>
     <text>You conjure a mass of sticky webbing at a point within range. The webs fill a 20-foot Cube there for the duration. The webs are Difficult Terrain, and the area within them is Lightly Obscured.
 
 If the webs aren't anchored between two solid masses (such as walls or trees) or layered across a floor, wall, or ceiling, the web collapses on itself, and the spell ends at the start of your next turn. Webs layered over a flat surface have a depth of 5 feet.
@@ -7374,7 +7374,7 @@ Source:	Player's Handbook 2024 p. 340</text>
     <range>120 feet</range>
     <components>V, S</components>
     <duration>Concentration, up to 1 minute</duration>
-    <classes>Warlock [2024], Wizard [2024]</classes>
+    <classes>School: Illusion, Warlock [2024], Wizard [2024]</classes>
     <text>You try to create illusory terrors in others' minds. Each creature of your choice in a 30-foot-radius Sphere centered on a point within range makes a Wisdom saving throw. On a failed save, a target takes 10d10 Psychic damage and has the Frightened condition for the duration. On a successful save, a target takes half as much damage only.
 
 A Frightened target makes a Wisdom saving throw at the end of each of its turns. On a failed save, it takes 5d10 Psychic damage. On a successful save, the spell ends on that target.
@@ -7391,7 +7391,7 @@ Source:	Player's Handbook 2024 p. 341</text>
     <range>30 feet</range>
     <components>V, S, M (a candle)</components>
     <duration>8 hour</duration>
-    <classes>Druid [2024]</classes>
+    <classes>School: Transmutation, Druid [2024]</classes>
     <text>You and up to ten willing creatures of your choice within range assume gaseous forms for the duration, appearing as wisps of cloud. While in this cloud form, a target has a Fly Speed of 300 feet and can hover; it has Immunity to the Prone condition; and it has Resistance to Bludgeoning, Piercing, and Slashing damage. The only actions a target can take in this form are the Dash action or a Magic action to begin reverting to its normal form. Reverting takes 1 minute, during which the target has the Stunned condition. Until the spell ends, the target can revert to cloud form, which also requires a Magic action followed by a 1-minute transformation.
 
 If a target is in cloud form and flying when the effect ends, the target descends 60 feet per round for 1 minute until it lands, which it does safely. If it can't land after 1 minute, it falls the remaining distance.
@@ -7406,7 +7406,7 @@ Source:	Player's Handbook 2024 p. 341</text>
     <range>120 feet</range>
     <components>V, S, M (a fan and a feather)</components>
     <duration>Concentration, up to 1 minute</duration>
-    <classes>Druid [2024], Ranger [2024]</classes>
+    <classes>School: Evocation, Druid [2024], Ranger [2024]</classes>
     <text>A wall of strong wind rises from the ground at a point you choose within range. You can make the wall up to 50 feet long, 15 feet high, and 1 foot thick. You can shape the wall in any way you choose so long as it makes one continuous path along the ground. The wall lasts for the duration.
 
 When the wall appears, each creature in its area makes a Strength saving throw, taking 4d8 Bludgeoning damage on a failed save or half as much damage on a successful one.
@@ -7424,7 +7424,7 @@ Source:	Player's Handbook 2024 p. 341</text>
     <range>Self</range>
     <components>V</components>
     <duration>Instantaneous</duration>
-    <classes>Sorcerer [2024], Wizard [2024]</classes>
+    <classes>School: Conjuration, Sorcerer [2024], Wizard [2024]</classes>
     <text>Wish is the mightiest spell a mortal can cast. By simply speaking aloud, you can alter reality itself.
 
 The basic use of this spell is to duplicate any other spell of level 8 or lower. If you use it this way, you don't need to meet any requirements to cast that spell, including costly components. The spell simply takes effect.
@@ -7466,7 +7466,7 @@ Source:	Player's Handbook 2024 p. 341</text>
     <range>60 feet</range>
     <components>V, S, M (a twig struck by lightning)</components>
     <duration>Concentration, up to 1 minute</duration>
-    <classes>Sorcerer [2024], Warlock [2024], Wizard [2024]</classes>
+    <classes>School: Evocation, Sorcerer [2024], Warlock [2024], Wizard [2024]</classes>
     <text>A beam of crackling energy lances toward a creature within range, forming a sustained arc of lightning between you and the target. Make a ranged spell attack against it. On a hit, the target takes 2d12 Lightning damage.
 
 On each of your subsequent turns, you can take a Bonus Action to deal 1d12 Lightning damage to the target automatically, even if the first attack missed.
@@ -7496,7 +7496,7 @@ Source:	Player's Handbook 2024 p. 343</text>
     <range>Self</range>
     <components>V, M (a sunburst token)</components>
     <duration>Instantaneous</duration>
-    <classes>Cleric [2024]</classes>
+    <classes>School: Evocation, Cleric [2024]</classes>
     <text>Burning radiance erupts from you in a 5-foot Emanation. Each creature of your choice that you can see in it must succeed on a Constitution saving throw or take 1d6 Radiant damage.
 
 Cantrip Upgrade: The damage increases by 1d6 when you reach levels 5 (2d6), 11 (3d6), and 17 (4d6).
@@ -7515,7 +7515,7 @@ Source:	Player's Handbook 2024 p. 343</text>
     <range>5 feet</range>
     <components>V</components>
     <duration>Instantaneous</duration>
-    <classes>Cleric [2024]</classes>
+    <classes>School: Conjuration, Cleric [2024]</classes>
     <text>You and up to five willing creatures within 5 feet of you instantly teleport to a previously designated sanctuary. You and any creatures that teleport with you appear in the nearest unoccupied space to the spot you designated when you prepared your sanctuary (see below). If you cast this spell without first preparing a sanctuary, the spell has no effect.
 
 You must designate a location, such as a temple, as a sanctuary by casting this spell there.
@@ -7530,7 +7530,7 @@ Source:	Player's Handbook 2024 p. 343</text>
     <range>Self</range>
     <components>V</components>
     <duration>1 minute</duration>
-    <classes>Paladin [2024]</classes>
+    <classes>School: Necromancy, Paladin [2024]</classes>
     <text>The target takes an extra 1d6 Necrotic damage from the attack, and it must succeed on a Wisdom saving throw or have the Frightened condition until the spell ends. At the end of each of its turns, the Frightened target repeats the save, ending the spell on itself on a success.
 
 Using a Higher-Level Spell Slot:
@@ -7555,7 +7555,7 @@ Source:	Player's Handbook 2024 p. 343</text>
     <range>Self</range>
     <components>V, S, M (a miniature tiara)</components>
     <duration>Concentration, up to 1 minute</duration>
-    <classes>Bard [2024], Wizard [2024], Paladin [2024] (Glory)</classes>
+    <classes>School: Enchantment, Bard [2024], Wizard [2024], Paladin [2024] (Glory)</classes>
     <text>You surround yourself with unearthly majesty in a 10-foot Emanation. Whenever the Emanation enters the space of a creature you can see and whenever a creature you can see enters the Emanation or ends its turn there, you can force that creature to make a Wisdom saving throw. On a failed save, the target takes 4d6 Psychic damage and has the Prone condition, and you can push it up to 10 feet away. On a successful save, the target takes half as much damage only. A creature makes this save only once per turn.
 
 Source:	Player's Handbook 2024 p. 343</text>
@@ -7569,7 +7569,7 @@ Source:	Player's Handbook 2024 p. 343</text>
     <range>60 feet</range>
     <components>V, S</components>
     <duration>10 minute</duration>
-    <classes>Bard [2024], Cleric [2024], Paladin [2024], Paladin [2024] (Devotion)</classes>
+    <classes>School: Enchantment, Bard [2024], Cleric [2024], Paladin [2024], Paladin [2024] (Devotion)</classes>
     <text>You create a magical zone that guards against deception in a 15-foot-radius Sphere centered on a point within range. Until the spell ends, a creature that enters the spell's area for the first time on a turn or starts its turn there makes a Charisma saving throw. On a failed save, a creature can't speak a deliberate lie while in the radius. You know whether a creature succeeds or fails on this save.
 
 An affected creature is aware of the spell and can avoid answering questions to which it would normally respond with a lie. Such a creature can be evasive yet must be truthful.


### PR DESCRIPTION
A bunch of fixes:
- Most T spells were added to "School: Transformation", some were added to "School: Transmutation". The application labels "school=T" spells as Transmutation, so I fixed all T spells to be in Transmutation school.
- 2024 spells were not added to School spell lists. Now they are there.
- XGE duplicated the Word of Radiance and Ice Knife spells. With next to no changes, I commented them out.
- TCE's optional expansion of base class spell lists were incorporated in 2024 which caused the app to show them twice in some spell lists.
- Ranger's prepared spells table were off.