### PR TITLE
Spell level fixed

### DIFF
--- a/Sources/PHB2014/ThirdParty/Indie/DungeonDudes/Sebastian_Crowes_Guide_To_Drakkenheim/spells-scgd.xml
+++ b/Sources/PHB2014/ThirdParty/Indie/DungeonDudes/Sebastian_Crowes_Guide_To_Drakkenheim/spells-scgd.xml
@@ -888,7 +888,7 @@ Source:	Sebastian Crowe's Guide to Drakkenheim p. 190 (Third Party)</text>
   </spell>
   <spell>
     <name>Touch of Death (HB)</name>
-    <level>1</level>
+    <level>9</level>
     <school>N</school>
     <time>1 Action</time>
     <range>Touch</range>


### PR DESCRIPTION
Touch of Death incorrectly labelled as level 1 spell - changed to level 9