### PR TITLE
FIX: errors regarding data comapred to PHB (Wizard, Rogue, Barbarian)

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/Sources/PHB2014/WizardsOfTheCoast/01_Core/01_Players_Handbook/class-barbarian-phb.xml
+++ b/Sources/PHB2014/WizardsOfTheCoast/01_Core/01_Players_Handbook/class-barbarian-phb.xml
@@ -126,6 +126,9 @@ If you are able to cast spells, you can't cast them or concentrate on them while
 	Once you have raged the maximum number of times for your barbarian level, you must finish a long rest before you can rage again. You may rage 2 times at 1st level, 3 at 3rd, 4 at 6th, 5 at 12th, and 6 at 17th.
 
 Source:	Player's Handbook (2014) p. 48</text>
+        <roll description="Rage Damage" level="1">+2</roll>
+        <roll description="Rage Damage" level="9">+3</roll>
+        <roll description="Rage Damage" level="16">+4</roll>
       </feature>
       <feature>
         <name>Unarmored Defense</name>

--- a/Sources/PHB2014/WizardsOfTheCoast/01_Core/01_Players_Handbook/class-rogue-phb.xml
+++ b/Sources/PHB2014/WizardsOfTheCoast/01_Core/01_Players_Handbook/class-rogue-phb.xml
@@ -289,14 +289,15 @@ Source:	Player's Handbook (2014) p. 94</text>
 
 Source:	Player's Handbook (2014) p. 94</text>
         <roll description="Extra Damage" level="1">1d6</roll>
-        <roll description="Extra Damage" level="2">2d6</roll>
-        <roll description="Extra Damage" level="3">3d6</roll>
-        <roll description="Extra Damage" level="4">4d6</roll>
-        <roll description="Extra Damage" level="5">5d6</roll>
-        <roll description="Extra Damage" level="6">6d6</roll>
-        <roll description="Extra Damage" level="7">7d6</roll>
-        <roll description="Extra Damage" level="8">8d6</roll>
-        <roll description="Extra Damage" level="9">9d6</roll>
+        <roll description="Extra Damage" level="3">2d6</roll>
+        <roll description="Extra Damage" level="5">3d6</roll>
+        <roll description="Extra Damage" level="7">4d6</roll>
+        <roll description="Extra Damage" level="9">5d6</roll>
+        <roll description="Extra Damage" level="11">6d6</roll>
+        <roll description="Extra Damage" level="13">7d6</roll>
+        <roll description="Extra Damage" level="15">8d6</roll>
+        <roll description="Extra Damage" level="17">9d6</roll>
+        <roll description="Extra Damage" level="19">10d6</roll>
       </feature>
       <feature>
         <name>Thieves' Cant</name>

--- a/Sources/PHB2014/WizardsOfTheCoast/01_Core/01_Players_Handbook/class-wizard-phb.xml
+++ b/Sources/PHB2014/WizardsOfTheCoast/01_Core/01_Players_Handbook/class-wizard-phb.xml
@@ -215,6 +215,18 @@ Your spellbook is a unique compilation of spells, with its own decorative flouri
 
 Source:	Player's Handbook (2014) p. 114</text>
       </feature>
+      <feature>
+        <name>Arcane Recovery</name>
+        <text>You have learned to regain some of your Magical energy by studying your Spellbook. Once per day when you finish a Short Rest, you can choose expended Spell Slots to recover. The Spell Slots can have a combined level that is equal to or less than half your Wizard level (rounded up), and none of the slots can be 6th Level or higher.
+	For example, if you're a 4th-level Wizard, you can recover up to two levels worth of Spell Slots. You can recover either a 2nd-level spell slot or two 1st-level Spell Slots.
+
+Source:	Player's Handbook (2014) p. 115</text>
+      </feature>
+      <counter>
+        <name>Arcane Recovery</name>
+        <value>1</value>
+        <reset>L</reset>
+      </counter>
     </autolevel>
     <autolevel level="2">
       <feature>
@@ -235,24 +247,12 @@ Source:	Player's Handbook (2014) p. 112</text>
       </feature>
     </autolevel>
     <autolevel level="6">
-      <feature>
-        <name>Arcane Recovery</name>
-        <text>You have learned to regain some of your Magical energy by studying your Spellbook. Once per day when you finish a Short Rest, you can choose expended Spell Slots to recover. The Spell Slots can have a combined level that is equal to or less than half your Wizard level (rounded up), and none of the slots can be 6th Level or higher.
-	For example, if you're a 4th-level Wizard, you can recover up to two levels worth of Spell Slots. You can recover either a 2nd-level spell slot or two 1st-level Spell Slots.
-
-Source:	Player's Handbook (2014) p. 115</text>
-      </feature>
       <feature optional="YES">
         <name>Arcane Tradition Feature</name>
         <text>At 6th level, you gain a feature granted by your Arcane Tradition.
 
 Source:	Player's Handbook (2014) p. 112</text>
       </feature>
-      <counter>
-        <name>Arcane Recovery</name>
-        <value>1</value>
-        <reset>L</reset>
-      </counter>
     </autolevel>
     <autolevel level="8" scoreImprovement="YES">
       <feature optional="YES">


### PR DESCRIPTION
## Summary of Fixes

### 1. Wizard - Arcane Recovery Level (class-wizard-phb.xml)

**Issue:** Arcane Recovery feature is at Level 6, should be at Level 1 per PHB p.115.

**PHB Reference:** "You have learned to regain some of your magical energy by studying your spellbook. Once per day when you finish a short rest..."

This is a 1st-level Wizard feature, gained alongside Spellcasting.

**Fix:** Move the `<feature>` element from `<autolevel level="6">` to `<autolevel level="1">`.

---

### 2. Rogue - Sneak Attack Roll Levels (class-rogue-phb.xml)

**Issue:** The `<roll>` elements for Sneak Attack use sequential levels 1-9, but Sneak Attack damage only increases at **odd** character levels (1, 3, 5, 7, 9, 11, 13, 15, 17, 19).

**PHB Reference (p.96):** "The amount of the extra damage increases by 1d6 every odd level you gain in this class, to a maximum of 10d6 at 19th level."

**Current (incorrect):**
```xml
<roll description="Extra Damage" level="1">1d6</roll>
<roll description="Extra Damage" level="2">2d6</roll>
<roll description="Extra Damage" level="3">3d6</roll>
...
<roll description="Extra Damage" level="9">9d6</roll>
```

**Correct:**
```xml
<roll description="Extra Damage" level="1">1d6</roll>
<roll description="Extra Damage" level="3">2d6</roll>
<roll description="Extra Damage" level="5">3d6</roll>
<roll description="Extra Damage" level="7">4d6</roll>
<roll description="Extra Damage" level="9">5d6</roll>
<roll description="Extra Damage" level="11">6d6</roll>
<roll description="Extra Damage" level="13">7d6</roll>
<roll description="Extra Damage" level="15">8d6</roll>
<roll description="Extra Damage" level="17">9d6</roll>
<roll description="Extra Damage" level="19">10d6</roll>
```

**Note:** Also adds the missing 10d6 at level 19.

---

### 3. Barbarian - Rage Damage Counter (class-barbarian-phb.xml)

**Issue:** No structured data for Rage Damage bonus progression. The values are only in prose text.

**PHB Reference (p.48):** "When you make a melee weapon attack using Strength, you gain a bonus to the damage roll that increases as you gain levels as a barbarian. At 1st level, you have a +2 bonus to damage. Your bonus increases to +3 at 9th level and to +4 at 16th."

**Suggested Addition:** Add `<roll>` elements to the Rage feature to capture this progression:

```xml
<roll description="Rage Damage" level="1">+2</roll>
<roll description="Rage Damage" level="9">+3</roll>
<roll description="Rage Damage" level="16">+4</roll>
```

This would allow applications to display the Rage Damage progression alongside other class progressions.
