### PR TITLE
fix: add character-level scaling rolls to Eldritch Blast

### DIFF
--- a/Sources/PHB2014/WizardsOfTheCoast/01_Core/01_Players_Handbook/spells-phb.xml
+++ b/Sources/PHB2014/WizardsOfTheCoast/01_Core/01_Players_Handbook/spells-phb.xml
@@ -2157,7 +2157,10 @@ Source:	Player's Handbook (2014) p. 236</text>
 	The spell creates more than one beam when you reach higher levels: two beams at 5th level, three beams at 11th level, and four beams at 17th level. You can direct the beams at the same target or at different ones. Make a separate attack roll for each beam.
 
 Source:	Player's Handbook (2014) p. 237</text>
-    <roll description="Force Damage">1d10</roll>
+    <roll description="Force Damage" level="0">1d10</roll>
+    <roll description="Force Damage" level="5">2d10</roll>
+    <roll description="Force Damage" level="11">3d10</roll>
+    <roll description="Force Damage" level="17">4d10</roll>
     <roll description="Agonizing Blast">1d10+%0</roll>
   </spell>
   <spell>


### PR DESCRIPTION
Add level attributes to Eldritch Blast roll elements to enable proper cantrip scaling detection in importer:
- level="0": 1d10 (1 beam)
- level="5": 2d10 (2 beams)
- level="11": 3d10 (3 beams)
- level="17": 4d10 (4 beams)
